### PR TITLE
fix #119

### DIFF
--- a/src/FSharp.Stats/Matrix.fs
+++ b/src/FSharp.Stats/Matrix.fs
@@ -549,7 +549,7 @@ module Matrix = begin
     let meanRowWise (a:matrix) =
         a
         |> sumRows
-        |> Vector.map (fun sum -> sum / (a.NumRows |> float))
+        |> Vector.map (fun sum -> sum / (a.NumCols |> float))
 
     /// Computes the Column wise mean of a Matrix
     let meanColumnWise (a:matrix) =


### PR DESCRIPTION
This should fix the behaviour described in #119, it was accidently divided by the number of rows instead of number of columns. 