### PR TITLE
add RowVector.map #134

### DIFF
--- a/src/FSharp.Stats/AlgTypes.fs
+++ b/src/FSharp.Stats/AlgTypes.fs
@@ -907,6 +907,9 @@ namespace FSharp.Stats
             let arrA = a.Values 
             createDenseMatrixGU a.OpsData a.NumRows a.NumCols (fun i j -> f i j (getArray2D arrA i j))
 
+        let mapRowVecGU f (a:RowVector<_>) = 
+            createRowVecGU a.OpsData a.NumCols (fun i -> f a.[i])
+
         let mapiRowVecGU f (a:RowVector<_>) = 
             createRowVecGU a.OpsData a.NumCols (fun i -> f i a.[i])
 
@@ -1409,8 +1412,12 @@ namespace FSharp.Stats
         let arraySM   xss : Matrix<'T>    = GU.mkSparseMatrixGU opsdata<'T> (Array2D.copy xss) |> sparse
         let arrayV    xss : Vector<'T>    = GU.mkVecGU          opsdata<'T> (Array.copy xss)
         let arrayRV   xss : RowVector<'T> = GU.mkRowVecGU       opsdata<'T> (Array.copy xss)
+        
+        let rowVecM xss: Matrix<'T>     = GU.rowvecDenseMatrixGU xss |> dense
+        let vecM    xss: Matrix<'T>     = GU.vectorDenseMatrixGU xss |> dense
 
         let seqM    xss : Matrix<'T>    = GU.seqDenseMatrixGU   opsdata<'T> xss |> dense
+        let seqCM   xss : Matrix<'T>    = GU.colSeqDenseMatrixGU   opsdata<'T> xss |> dense
         let seqV    xss : Vector<'T>    = GU.seqVecGU           opsdata<'T> xss
         let seqRV   xss : RowVector<'T> = GU.seqRowVecGU        opsdata<'T> xss
 
@@ -1848,6 +1855,8 @@ namespace FSharp.Stats
         let mapiV  f a = GU.mapiVecGU f a
         let permuteV p a = GU.permuteVecGU p a
         let permuteRV p a = GU.permuteRowVecGU p a
+        
+        let mapRV f a = GU.mapRowVecGU f a
 
         let mapiRV  f a = GU.mapiRowVecGU f a
 

--- a/src/FSharp.Stats/FSharp.Stats.fsproj
+++ b/src/FSharp.Stats/FSharp.Stats.fsproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Remove="Scripts\**" />
-    <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath=""/>
+    <None Include="..\..\docs\img\logo.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Ops.fs" />

--- a/src/FSharp.Stats/FSharp.Stats.fsproj
+++ b/src/FSharp.Stats/FSharp.Stats.fsproj
@@ -47,8 +47,8 @@
     <Compile Include="List.fs" />
     <Compile Include="JaggedArray.fs" />
     <Compile Include="Vector.fs" />
-    <Compile Include="Matrix.fs" />
     <Compile Include="RowVector.fs" />
+    <Compile Include="Matrix.fs" />
     <Compile Include="MatrixTopLevelOperators.fs" />
     <Compile Include="Rank.fs" />
     <Compile Include="Correlation.fs" />

--- a/src/FSharp.Stats/ML/Unsupervised/GapStatistics.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/GapStatistics.fs
@@ -299,7 +299,7 @@ https://www.datanovia.com/en/lessons/determining-the-optimal-number-of-clusters-
         // Calculate log(sum_i(within-cluster_i sum of squares around cluster_i mean)) of kmeans clustering result.
         let logDispersionKMeansInitCvMax = 
             let aggregator = IterativeClustering.avgCentroid
-            let factory = IterativeClustering.intitCVMAX 
+            let factory = IterativeClustering.initCVMAX 
             let clusterDispersion (cluster:float[][]) =
                 let distances =
                     cluster 

--- a/src/FSharp.Stats/ML/Unsupervised/IterativeClustering.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/IterativeClustering.fs
@@ -51,17 +51,14 @@ module IterativeClustering =
 
 
 
-    // cvmax - Algorith by Moth’d Belal. Al-Daoud (Ref.: A New Algorithm for Cluster Initialization)
-    let intitCVMAX (sample: float[] array) k =
-        let dmatrix = matrix sample
+    // cvmax - Algorithm by Moth’d Belal. Al-Daoud (Ref.: A New Algorithm for Cluster Initialization)
+    let initCVMAX (sampleRows: float[] []) k =
+        let dmatrix = matrix sampleRows
         let cvmax =
-            dmatrix
-            |> Matrix.Generic.enumerateColumnWise Seq.var
-            |> Seq.zip (Matrix.Generic.enumerateColumnWise id dmatrix)
-            |> Seq.maxBy snd
-            |> fst
-            |> Seq.mapi (fun rowI value -> (rowI,value)) 
-            |> Seq.toArray 
+            sampleRows
+            |> JaggedArray.transpose
+            |> Array.maxBy Seq.var
+            |> Array.indexed
             |> Array.sortBy snd
                     
         if cvmax.Length < k then failwithf "Number of data points must be at least %i" k        
@@ -78,7 +75,7 @@ module IterativeClustering =
                 | x                       -> chunkSize * (i - 1) + ((cvmax.Length - chunkSize * (i - 1)) / 2)
             //printfn "Array.lenght = %i and index = %i" cvmax.Length (index-1)
             yield cvmax.[index-1] |> fst]
-        |> Seq.map (fun rowI -> dmatrix.Row(rowI).ToArray())
+        |> Seq.map (fun rowI -> sampleRows.[rowI])
         |> Seq.toArray
 
 //    // cvmax - Algorith by Moth’d Belal. Al-Daoud (Ref.: A New Algorithm for Cluster Initialization)

--- a/src/FSharp.Stats/ML/Unsupervised/PrincipalComponentAnalysis.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/PrincipalComponentAnalysis.fs
@@ -66,7 +66,7 @@ module PCA =
             data |> Matrix.meanColumnWise                    
         // Atttention: not entierly shure if space of data before
         let colStDev =
-            data |> Matrix.Generic.enumerateColumnWise Seq.stDevPopulation |> Seq.toArray
+            data |> Matrix.Generic.mapCols Seq.stDevPopulation |> Seq.toArray
      
         let adjust (direction:AdjustmentDirection) (aData:Matrix<float>) = 
             match direction with
@@ -88,11 +88,11 @@ module PCA =
     /// Returns an AdjustmentFactory which centers and standardize the data
     let toAdjustCorrelation (data:Matrix<float>) : AdjustmentFactory =                
         let colMeans =
-            data |> Matrix.meanColumnWise                    
-        let sqrtI = sqrt (float data.NumRows)
-        // Atttention: not entierly shure if space of data before
+            data |> Matrix.meanColumnWise 
+        let sqrtI = sqrt (float data.NumRows)                   
+        // Attention: not entirely sure if space of data before
         let colStDev =
-            data |> Matrix.Generic.enumerateColumnWise Seq.stDevPopulation |> Seq.toArray    
+            data |> Matrix.Generic.mapCols Seq.stDevPopulation |> Seq.toArray    
         let adjust (direction:AdjustmentDirection)  (aData:Matrix<float>) = 
             match direction with
             | Obverse ->

--- a/src/FSharp.Stats/RowVector.fs
+++ b/src/FSharp.Stats/RowVector.fs
@@ -43,7 +43,7 @@ module RowVector =
         let of_seq a         = ofSeq a
         [<Obsolete("Use toArray instead.")>]
         let to_array m       = toArray m
-
+        let map mapping (a:RowVector<_>) = OpsS.mapRV mapping a 
 
     module RVG = Generic
 
@@ -70,7 +70,9 @@ module RowVector =
     let of_array arr = ofArray arr
     [<Obsolete("Use toArray instead.")>]
     let to_array m   = toArray m
-
+    ///Builds a new rowvector whose elements are the results of applying the given function to each of the elements of the rowvector.
+    let map mapping (rowvec:rowvec) = RVG.map mapping rowvec
+    
 
 
 

--- a/src/FSharp.Stats/Signal/Normalization.fs
+++ b/src/FSharp.Stats/Signal/Normalization.fs
@@ -23,16 +23,15 @@ module Normalization =
     ///
     /// The additional function is applied on all values of the matrix when calculating the normalization factors. By this, a zero in the original dataset will still remain zero.
     let medianOfRatiosBy (f: float -> float) (data:Matrix<float>) =
-        let sampleWiseCorrectionFactors =
+        let sampleWiseCorrectionFactors =            
             data
-            |> Matrix.mapiRows (fun _ v -> 
-                let v = Seq.map f v
+            |> Matrix.mapiRows (fun _ v ->
+                let v = RowVector.map f v
                 let geometricMean = Seq.meanGeometric v           
-                Seq.map (fun s -> s / geometricMean) v
+                RowVector.map (fun s -> s / geometricMean) v
                 ) 
-            |> matrix
+            |> Matrix.ofRows
             |> Matrix.mapiCols (fun _ v -> Vector.median v)
-            |> vector
         data
         |> Matrix.mapi (fun r c v ->
             v / sampleWiseCorrectionFactors.[c]
@@ -53,13 +52,12 @@ module Normalization =
         let sampleWiseCorrectionFactors =
             data
             |> Matrix.mapiCols (fun _ v -> 
-                let v = Seq.map f v
+                let v = Vector.map f v
                 let geometricMean = Seq.meanGeometric v           
-                Seq.map (fun s -> s / geometricMean) v
+                Vector.map (fun s -> s / geometricMean) v
                 ) 
-            |> matrix
-            |> Matrix.mapiCols (fun _ v -> Seq.median v)
-            |> vector
+            |> Matrix.ofCols
+            |> Matrix.mapiRows (fun _ v -> Seq.median v)
         data
         |> Matrix.mapi (fun r c v ->
             v / sampleWiseCorrectionFactors.[r]

--- a/tests/FSharp.Stats.Tests/FSharp.Stats.Tests.fsproj
+++ b/tests/FSharp.Stats.Tests/FSharp.Stats.Tests.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Distributions.fs" />
     <Compile Include="Vector.fs" />
     <Compile Include="Matrix.fs" />
+    <Compile Include="RowVector.fs" />
     <Compile Include="ML.fs" />
     <Compile Include="Signal.fs" />
     <Compile Include="SpecialFunctions.fs" />

--- a/tests/FSharp.Stats.Tests/Main.fs
+++ b/tests/FSharp.Stats.Tests/Main.fs
@@ -9,6 +9,9 @@ let main argv =
     //================================ Vector ===============================================================
     Tests.runTestsWithCLIArgs [] argv VectorTests.covarianceTests               |> ignore
 
+    //================================ RowVor ===============================================================
+    Tests.runTestsWithCLIArgs [] argv RowVectorTests.floatImplementationTests   |> ignore
+
     //=========================== Special Functions =========================================================    
     Tests.runTestsWithCLIArgs [] argv SpecialFunctionsTests.gammaFunctionsTests |> ignore
     Tests.runTestsWithCLIArgs [] argv SpecialFunctionsTests.betaFunctionsTests  |> ignore

--- a/tests/FSharp.Stats.Tests/Matrix.fs
+++ b/tests/FSharp.Stats.Tests/Matrix.fs
@@ -256,6 +256,24 @@ let floatImplementationDenseTests =
                     Matrix.init 3 3 (fun i j -> testValuesArrRows.[i].[j])
                 Expect.equal actual testSquareMatrixA "Matrix was not initialized correctly using Matrix.init"
                 
+            testCase "ofRows" <| fun () ->
+                let actual =
+                    testValuesArrRows
+                    |> Array.map rowvec
+                    |> Vector.Generic.ofSeq
+                    |> Matrix.ofRows
+
+                Expect.equal actual testSquareMatrixA "Matrix was not initialized correctly using Matrix.ofRows"
+            
+            testCase "ofCols" <| fun () ->
+                let actual =
+                    testValuesArrCols
+                    |> Array.map vector
+                    |> RowVector.Generic.ofSeq
+                    |> Matrix.ofCols
+
+                Expect.equal actual testSquareMatrixA "Matrix was not initialized correctly using Matrix.ofCols"      
+                
             testCase "ofJaggedList" <| fun () ->
 
                 let actual =
@@ -371,10 +389,21 @@ let floatImplementationDenseTests =
                 Expect.equal actual expected "Matrix.toArray2D did not return the correct Array2D"
 
             testCase "toJaggedArray" <| fun () ->
-
                 let actual = Matrix.toJaggedArray testSquareMatrixA
+                Expect.equal actual testValuesArrRows "Matrix.toJaggedArray did not return the correct JaggedArray"
 
-                Expect.equal actual testValuesArrRows "Matrix.toArray2D did not return the correct JaggedArray"
+            testCase "toJaggedSeq" <| fun () ->
+                let actual = Matrix.toJaggedSeq testSquareMatrixA |> JaggedArray.ofJaggedSeq
+                Expect.equal actual testValuesArrRows "Matrix.toJaggedSeq did not return the correct JaggedSeq"
+            
+            testCase "toJaggedColArray" <| fun () ->
+                let actual = Matrix.toJaggedColArray testSquareMatrixA
+                Expect.equal actual testValuesArrCols "Matrix.toJaggedColArray did not return the correct JaggedArray"
+
+            testCase "toJaggedColSeq" <| fun () ->
+                let actual = Matrix.toJaggedColSeq testSquareMatrixA |> JaggedArray.ofJaggedSeq
+                Expect.equal actual testValuesArrCols "Matrix.toJaggedColSeq did not return the correct JaggedSeq"
+
 
             testCase "getDiagN 1 above diagonal" <| fun () ->
                     
@@ -775,6 +804,56 @@ let floatImplementationDenseTests =
                             )
                     Expect.equal actual identityFloat3 "creating identity matrix using Matrix.mapi failed"
 
+            ]
+            testList "mapRows" [
+                
+                testCase "map with Seq.mean" <| fun () ->
+                    let actual = 
+                        testSquareMatrixA
+                        |> Matrix.mapRows Seq.mean
+
+                    let expected =
+                        Vector.init
+                            3
+                            (fun i -> Seq.mean testValuesArrRows.[i])
+
+                    Expect.equal actual expected "Mapping the rows of a test matrix with Seq.mean did not return the correct result"
+            ]
+            testList "mapCols" [
+                
+                testCase "map with Seq.mean" <| fun () ->
+                    let actual = 
+                        testSquareMatrixA
+                        |> Matrix.mapCols Seq.mean
+
+                    let expected =
+                        RowVector.init 3 (fun i -> Seq.mean testValuesArrCols.[i])
+
+                    Expect.equal actual expected "Mapping the cols of a test matrix with Seq.mean did not return the correct result"
+            ]
+            testList "mapiRows" [
+                
+                testCase "mapi with Seq.mean" <| fun () ->
+                    let actual = 
+                        testSquareMatrixA
+                        |> Matrix.mapiRows (fun i x -> float i * Seq.mean x)
+
+                    let expected =
+                        Vector.init 3 (fun i -> float i * Seq.average testValuesArrRows.[i])
+
+                    Expect.equal actual expected "Mapping the rows of a test matrix with Seq.mean did not return the correct result"
+            ]
+            testList "mapiCols" [
+                
+                testCase "mapi with Seq.mean" <| fun () ->
+                    let actual = 
+                        testSquareMatrixA
+                        |> Matrix.mapiCols (fun i x -> float i * Seq.mean x)
+
+                    let expected =
+                        RowVector.init 3 (fun i -> float i * Seq.average testValuesArrCols.[i])
+
+                    Expect.equal actual expected "Mapping the columns of a test matrix with Seq.mean did not return the correct result"
             ]
             testList "fold" [
                 

--- a/tests/FSharp.Stats.Tests/RowVector.fs
+++ b/tests/FSharp.Stats.Tests/RowVector.fs
@@ -1,0 +1,28 @@
+module RowVectorTests 
+open Expecto
+
+open FSharp.Stats
+open FSharp.Stats.RowVector
+
+let private testRowVectorA =
+    let values = [|5.;12.;18.;-23.;45.|]
+    RowVector<float>(Some (Instances.FloatNumerics :> INumeric<float>),values)
+
+let private testArrayA =
+    [|5.;12.;18.;-23.;45.|]
+    
+[<Tests>]
+let floatImplementationTests =
+    let testRowVectorASquare = rowvec [25.0; 144.0; 324.0; 529.0; 2025.]
+
+    testList "RowVector" [
+        testCase "map" <| fun () -> 
+            let actual = testRowVectorA |> RowVector.map (fun x -> x**2.)
+            Expect.equal actual testRowVectorASquare "RowVectors should be equal"
+
+        testCase "init" <| fun () -> 
+            let actual = RowVector.init testArrayA.Length (fun i -> testArrayA.[i])
+            Expect.equal actual testRowVectorA "RowVectors should be equal"
+    ]
+
+


### PR DESCRIPTION
regarding #134 
add Matrix.mapRows
add Matrix.mapCols
add RowVector.map
add Matrix.ofCols `RowVector<Vector<float>> -> Matrix<float>`
add Matrix.ofRows `Vector<RowVector<float>> -> Matrix<float>`
change Matrix.mapiRows from output type `seq<#seq<'a>>` to `Vector<'b>`
change Matrix.mapiCols from output type `seq<#seq<'a>>` to `RowVector<'b>`
deprecate Matrix.enumerateRowWise
deprecate Matrix.enumerateColWise