### PR TITLE
1) Make Quantile.compute (and others) use OfSorted.* internally and allow sequence input

### DIFF
--- a/src/FSharp.Stats/Quantile.fs
+++ b/src/FSharp.Stats/Quantile.fs
@@ -252,65 +252,77 @@ module Quantile =
     /// Estimates the q-th quantile from the unsorted data.
     /// Approximately median-unbiased regardless of the sample distribution.
     let inline compute q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.compute q data'
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let h  = ((float data.Length + 1./3.)*q + 1./3.)
+        let h' = h |> int
+        
+        if (q < 0. || q > 1. || data.Length = 0) then
+            nan
+        elif (h' <= 0 || q = 0.) then
+            Array.min data
+        elif (h' >= data.Length || q = 1.) then
+            Array.max data
+        else
+            let data' = Array.copy data
+            let a = Array.quickSelectInPlace (h') data'
+            let b = Array.quickSelectInPlace (h'+1) data'
+            a + (h - float h') * (b - a); 
 
     /// Estimates the q-th quantile from the unsorted data.
     let empiricalInvCdf q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.empiricalInvCdf q data'
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.empiricalInvCdfInPLace q data'
     
     
     /// Estimates the q-th quantile from the unsorted data.
     let empiricalInvCdfAverage q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.empiricalInvCdfAverage q data'        
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.empiricalInvCdfAverageInPLace q data'        
 
 
     /// Estimates the q-th quantile from the unsorted data.
     let nearest q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.nearest q data'   
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.nearestInPLace q data'   
         
      
     /// Estimates the q-th quantile from the unsorted data.
     let california q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.california q data'
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.californiaInPLace q data'
     
     
     /// Estimates the q-th quantile from the unsorted data.
     let hazen q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.hazen q data'        
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.hazenInPLace q data'        
 
 
     /// Estimates the q-th quantile from the unsorted data.
     let nist q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.nist q data'
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.nistInPLace q data'
     
     
     /// Estimates the q-th quantile from the unsorted data.
     /// R! default
     let mode q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.mode q data'        
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.modeInPLace q data'        
     
     
     /// Estimates the q-th quantile from the unsorted data.
     let normal q (data:seq<_>) =
-        let data' = Seq.toArray data
-        Array.sortInPlace data'
-        OfSorted.normal q data'
+        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data' = Array.copy data
+        InPlace.normalInPLace q data'
 
 
 

--- a/src/FSharp.Stats/Quantile.fs
+++ b/src/FSharp.Stats/Quantile.fs
@@ -249,74 +249,68 @@ module Quantile =
 
     // ++++++++++++++++++++++++++++++++++++
 
-    /// Estimates the q-th quantile from the unsorted data array.
+    /// Estimates the q-th quantile from the unsorted data.
     /// Approximately median-unbiased regardless of the sample distribution.
-    /// NOTE: If duplicates exist 'Quantile.OfSorted.compute' is much faster!
-    let inline compute q (data:array<_>) =
-        
-        let h  = ((float data.Length + 1./3.)*q + 1./3.)
-        let h' = h |> int
-        
-        if (q < 0. || q > 1. || data.Length = 0) then
-            nan
-        elif (h' <= 0 || q = 0.) then
-            Array.min data
-        elif (h' >= data.Length || q = 1.) then
-            Array.max data
-        else
-            let data' = Array.copy data
-            let a = Array.quickSelectInPlace (h') data'
-            let b = Array.quickSelectInPlace (h'+1) data'
-            a + (h - float h') * (b - a); 
+    let inline compute q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.compute q data'
 
-
-    /// Estimates the q-th quantile from the unsorted data array.
-    let empiricalInvCdf q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.empiricalInvCdfInPLace q data'
+    /// Estimates the q-th quantile from the unsorted data.
+    let empiricalInvCdf q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.empiricalInvCdf q data'
     
     
-    /// Estimates the q-th quantile from the unsorted data array.
-    let empiricalInvCdfAverage q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.empiricalInvCdfAverageInPLace q data'        
+    /// Estimates the q-th quantile from the unsorted data.
+    let empiricalInvCdfAverage q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.empiricalInvCdfAverage q data'        
 
 
-    /// Estimates the q-th quantile from the unsorted data array.
-    let nearest q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.nearestInPLace q data'   
+    /// Estimates the q-th quantile from the unsorted data.
+    let nearest q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.nearest q data'   
         
      
-    /// Estimates the q-th quantile from the unsorted data array.
-    let california q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.californiaInPLace q data'
+    /// Estimates the q-th quantile from the unsorted data.
+    let california q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.california q data'
     
     
-    /// Estimates the q-th quantile from the unsorted data array.
-    let hazen q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.hazenInPLace q data'        
+    /// Estimates the q-th quantile from the unsorted data.
+    let hazen q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.hazen q data'        
 
 
-    /// Estimates the q-th quantile from the unsorted data array.
-    let nist q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.nistInPLace q data'
+    /// Estimates the q-th quantile from the unsorted data.
+    let nist q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.nist q data'
     
     
-    /// Estimates the q-th quantile from the unsorted data array.
+    /// Estimates the q-th quantile from the unsorted data.
     /// R! default
-    let mode q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.modeInPLace q data'        
+    let mode q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.mode q data'        
     
     
-    /// Estimates the q-th quantile from the unsorted data array.
-    let normal q (data:array<_>) =
-        let data' = Array.copy data
-        InPlace.normalInPLace q data'
+    /// Estimates the q-th quantile from the unsorted data.
+    let normal q (data:seq<_>) =
+        let data' = Seq.toArray data
+        Array.sortInPlace data'
+        OfSorted.normal q data'
 
 
 

--- a/src/FSharp.Stats/Quantile.fs
+++ b/src/FSharp.Stats/Quantile.fs
@@ -252,76 +252,71 @@ module Quantile =
     /// Estimates the q-th quantile from the unsorted data.
     /// Approximately median-unbiased regardless of the sample distribution.
     let inline compute q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
+        let data = Seq.UtilityFunctions.toArrayCopyQuick data
         let h  = ((float data.Length + 1./3.)*q + 1./3.)
         let h' = h |> int
         
         if (q < 0. || q > 1. || data.Length = 0) then
             nan
         elif (h' <= 0 || q = 0.) then
-            Array.min data
+            if Array.exists nan.Equals data then 
+                nan 
+            else Array.min data
         elif (h' >= data.Length || q = 1.) then
-            Array.max data
+            if Array.exists nan.Equals data then 
+                nan 
+            else Array.max data
         else
-            let data' = Array.copy data
-            let a = Array.quickSelectInPlace (h') data'
-            let b = Array.quickSelectInPlace (h'+1) data'
+            let a = Array.quickSelectInPlace (h') data
+            let b = Array.quickSelectInPlace (h'+1) data
             a + (h - float h') * (b - a); 
 
     /// Estimates the q-th quantile from the unsorted data.
     let empiricalInvCdf q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.empiricalInvCdfInPLace q data'
     
     
     /// Estimates the q-th quantile from the unsorted data.
     let empiricalInvCdfAverage q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.empiricalInvCdfAverageInPLace q data'        
 
 
     /// Estimates the q-th quantile from the unsorted data.
     let nearest q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.nearestInPLace q data'   
         
      
     /// Estimates the q-th quantile from the unsorted data.
     let california q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.californiaInPLace q data'
     
     
     /// Estimates the q-th quantile from the unsorted data.
     let hazen q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.hazenInPLace q data'        
 
 
     /// Estimates the q-th quantile from the unsorted data.
     let nist q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.nistInPLace q data'
     
     
     /// Estimates the q-th quantile from the unsorted data.
     /// R! default
     let mode q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.modeInPLace q data'        
     
     
     /// Estimates the q-th quantile from the unsorted data.
     let normal q (data:seq<_>) =
-        let data = Seq.UtilityFunctions.toArrayQuick data
-        let data' = Array.copy data
+        let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.normalInPLace q data'
 
 

--- a/src/FSharp.Stats/Quantile.fs
+++ b/src/FSharp.Stats/Quantile.fs
@@ -137,7 +137,7 @@ module Quantile =
     module OfSorted =
 
         /// ! Input needs to be sorted !
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         /// Approximately median-unbiased regardless of the sample distribution.
         let compute q (data:array<_>) =
         
@@ -156,7 +156,7 @@ module Quantile =
                 a + (h - float h') * (b - a);    
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let empiricalInvCdf q (data:array<_>) =
             let f q (data:array<_>) =
                 let h = float data.Length * q + 0.5
@@ -165,7 +165,7 @@ module Quantile =
             quantileHelper f q data
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let empiricalInvCdfAverage q (data:array<_>) =
 
             let f q (data:array<_>) =
@@ -177,7 +177,7 @@ module Quantile =
             quantileHelper f q data
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let nearest q (data:array<_>) =
             let f q (data:array<_>) =
                 let h = float data.Length * q
@@ -186,7 +186,7 @@ module Quantile =
             quantileHelper f q data
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let california q (data:array<_>) =
             let f q (data:array<_>) =
                 let h  = float data.Length * q
@@ -198,7 +198,7 @@ module Quantile =
             quantileHelper f q data
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let hazen q (data:array<_>) =
             let f q (data:array<_>) =
                 let h  = float data.Length * q + 0.5
@@ -210,7 +210,7 @@ module Quantile =
             quantileHelper f q data        
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let nist q (data:array<_>) =
             let f q (data:array<_>) =
                 let h  = float (data.Length+1) * q
@@ -222,7 +222,7 @@ module Quantile =
             quantileHelper f q data
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let mode q (data:array<_>) =
             let f q (data:array<_>) =                
                 let h  = float (data.Length-1) * q + 1.
@@ -234,7 +234,7 @@ module Quantile =
             quantileHelper f q data
 
 
-        /// Estimates the q-th quantile from the unsorted data array. (in place)
+        /// Estimates the q-th quantile from the sorted data array.
         let normal q (data:array<_>) =
             let f q (data:array<'a>) =                
                 let h  = (float data.Length + 0.25) * q + 0.375

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -1142,6 +1142,10 @@ module Seq =
         let pooledStDevPopulation (data:seq<#seq<float>>) = 
             sqrt (pooledVarPopulation data)
 
+        let inline internal toArrayQuick (xs: seq<'T>) =
+            match xs with
+            | :? ('T[]) as arr -> arr
+            | _ -> Seq.toArray xs
 
 //    // ########################################################################
 //    /// A module which implements functional matrix operations.

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -1142,9 +1142,16 @@ module Seq =
         let pooledStDevPopulation (data:seq<#seq<float>>) = 
             sqrt (pooledVarPopulation data)
 
+        ///Converts the input sequence to an array if it not already is an array.
         let inline internal toArrayQuick (xs: seq<'T>) =
             match xs with
             | :? ('T[]) as arr -> arr
+            | _ -> Seq.toArray xs
+
+        ///Like toArrayQuick but if the input sequence is an array already, it is copied to a new one to not interfere with inplace operations
+        let inline internal toArrayCopyQuick (xs: seq<'T>) =
+            match xs with
+            | :? ('T[]) as arr -> Array.copy arr
             | _ -> Seq.toArray xs
 
 //    // ########################################################################

--- a/tests/FSharp.Stats.Tests/FSharp.Stats.Tests.fsproj
+++ b/tests/FSharp.Stats.Tests/FSharp.Stats.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="SpecialFunctions.fs" />
     <Compile Include="Testing.fs" />
     <Compile Include="Fitting.fs" />
+    <Compile Include="Quantile.fs" />
     <Compile Include="Rank.fs" />
     <Compile Include="Main.fs" />
 

--- a/tests/FSharp.Stats.Tests/Fitting.fs
+++ b/tests/FSharp.Stats.Tests/Fitting.fs
@@ -6,9 +6,9 @@ open FSharp.Stats
 open FSharp.Stats.Fitting
 open FSharp.Stats.Fitting.NonLinearRegression
 
-let compareSeq (a:seq<float>) (b:seq<float>) (str:string) =
-    Seq.iter2 (fun a b -> Expect.floatClose Accuracy.high a b str) a b
-
+let compareSeq accuracy (a:seq<float>) (b:seq<float>) (str:string) =
+    Seq.iter2 (fun a b -> Expect.floatClose accuracy a b str) a b
+    
 [<Tests>]
 let nonLinearRegressionTests = 
     let time = [|0.083;0.25;0.5;0.75;1.0;2.0;3.0;4.0;5.0;6.0;7.0;8.0;9.0;10.0|]
@@ -99,7 +99,7 @@ let splineTests =
                     |]
                     |> Array.concat
                 
-                compareSeq fits results "The fitted spline does not yield the expected predictions."   
+                compareSeq Accuracy.high fits results "The fitted spline does not yield the expected predictions."   
                 
         ]
 

--- a/tests/FSharp.Stats.Tests/Main.fs
+++ b/tests/FSharp.Stats.Tests/Main.fs
@@ -20,14 +20,14 @@ let main argv =
     Tests.runTestsWithCLIArgs [] argv LinearAlgebraTests.managedSVDTests   |> ignore
 
     //================================== List ===============================================================
-    Tests.runTestsWithCLIArgs [] argv ListTests.medianTests   |> ignore
+    Tests.runTestsWithCLIArgs [] argv ListTests.medianTests |> ignore
     Tests.runTestsWithCLIArgs [] argv ListTests.meanTests   |> ignore
 
     //================================== Array ==============================================================
     Tests.runTestsWithCLIArgs [] argv ArrayTests.medianTests   |> ignore
 
     //================================= Seq ==============================================================
-    Tests.runTestsWithCLIArgs [] argv SeqTests.medianTests   |> ignore
+    Tests.runTestsWithCLIArgs [] argv SeqTests.medianTests |> ignore
     Tests.runTestsWithCLIArgs [] argv SeqTests.meanTests   |> ignore
 
     //============================= Distributions ===========================================================
@@ -43,9 +43,9 @@ let main argv =
     
     //=============================== Covariance ============================================================
     Tests.runTestsWithCLIArgs [] argv CovarianceTests.sequenceTests |> ignore
-    Tests.runTestsWithCLIArgs [] argv CovarianceTests.listTests |> ignore
-    Tests.runTestsWithCLIArgs [] argv CovarianceTests.arrayTests |> ignore
-    Tests.runTestsWithCLIArgs [] argv CovarianceTests.matrixTests |> ignore
+    Tests.runTestsWithCLIArgs [] argv CovarianceTests.listTests     |> ignore
+    Tests.runTestsWithCLIArgs [] argv CovarianceTests.arrayTests    |> ignore
+    Tests.runTestsWithCLIArgs [] argv CovarianceTests.matrixTests   |> ignore
     
     //================================ Testing ==============================================================
     //Tests.runTestsWithCLIArgs [] argv TestingTests.testPostHocTests |> ignore 
@@ -62,7 +62,13 @@ let main argv =
     Tests.runTestsWithCLIArgs [] argv MLTests.SimilarityMetrics.tverskySymmetricIndexTests  |> ignore
 
     //================================== Fitting ============================================================
-    Tests.runTestsWithCLIArgs [] argv FittingTests.nonLinearRegressionTests      |> ignore
-    Tests.runTestsWithCLIArgs [] argv FittingTests.leastSquaresCholeskyTests    |> ignore
-    Tests.runTestsWithCLIArgs [] argv FittingTests.splineTests      |> ignore
+    Tests.runTestsWithCLIArgs [] argv FittingTests.nonLinearRegressionTests  |> ignore
+    Tests.runTestsWithCLIArgs [] argv FittingTests.leastSquaresCholeskyTests |> ignore
+    Tests.runTestsWithCLIArgs [] argv FittingTests.splineTests               |> ignore
+
+    //================================== Quantile ============================================================
+    Tests.runTestsWithCLIArgs [] argv QuantileTests.quantileDefaultTests  |> ignore
+    Tests.runTestsWithCLIArgs [] argv QuantileTests.quantileTests         |> ignore
+    Tests.runTestsWithCLIArgs [] argv QuantileTests.quantileOfSortedTests |> ignore
+
     0

--- a/tests/FSharp.Stats.Tests/Quantile.fs
+++ b/tests/FSharp.Stats.Tests/Quantile.fs
@@ -1,0 +1,242 @@
+﻿module QuantileTests
+
+open System
+open FSharp.Stats
+open Expecto
+
+
+let rnd = System.Random(1)
+let testSeq1   = seq {20.;-0.5;0.9649;-0.4;0.0;0.1;0.7;12.;4.7;100.;0.0;0.65}
+let testList1  = FSharp.Collections.List.ofSeq testSeq1
+let testArray1 = FSharp.Collections.Array.ofList testList1
+let testArrayLong = Array.init 10000 (fun _ -> rnd.NextDouble())
+let testArrayNaN  = Array.append testArray1 [|nan|]
+let testArrayDuplicates = Array.append (Array.init 100 (fun _ -> 0.)) testArray1
+let percentiles = [|-1.;0.;0.1;0.5;0.9;1.;1.1|]
+
+let expectedShort = [|nan; -0.5; -0.4433333333; 0.675; 54.66666667; 100.0; nan|] //type 8
+//Type=1; Inverse of empirical distribution function
+let expected1 = [|nan;5.634874108e-05;9.657269255e-02;4.949744681e-01;8.972069658e-01;9.999589436e-01;nan|]
+//Type=2; Similar to type 1 but with averaging at discontinuities.
+let expected2 = [|nan;5.634874108e-05;9.664607728e-02;4.950177730e-01;8.972569624e-01;9.999589436e-01;nan|]
+//Type=3; SAS definition: nearest even order statistic
+let expected3 = [|nan;5.634874108e-05;9.657269255e-02;4.949744681e-01;8.972069658e-01;9.999589436e-01;nan|]
+//Type=4; linear interpolation of the empirical cdf.
+let expected4 = [|nan;5.634874108e-05;9.657269255e-02;4.949744681e-01;8.972069658e-01;9.999589436e-01;nan|]
+//Type=5; That is a piecewise linear function where the knots are the values midway through the steps of the empirical cdf
+let expected5 = [|nan;5.634874108e-05;9.664607728e-02;4.950177730e-01;8.972569624e-01;9.999589436e-01;nan|]
+//Type=6; This is used by Minitab and by SPSS
+let expected6 = [|nan;5.634874108e-05;9.658736950e-02;4.950177730e-01;8.972969598e-01;9.999589436e-01;nan|]
+//Type=7; This is used by S
+let expected7 = [|nan;5.634874108e-05;9.670478506e-02;4.950177730e-01;8.972169651e-01;9.999589436e-01;nan|]
+//Type=8; The resulting quantile estimates are approximately median-unbiased regardless of the distribution of x
+let expected8 = [|nan;5.634874108e-05;9.662650802e-02;4.950177730e-01;8.972702949e-01;9.999589436e-01;nan|]
+//Type=9; The resulting quantile estimates are approximately unbiased for the expected order statistics if x is normally distributed.
+let expected9 = [|nan;5.634874108e-05;9.663140033e-02;4.950177730e-01;8.972669618e-01;9.999589436e-01;nan|]
+    
+
+[<Tests>]
+let quantileDefaultTests =
+    //tested against R stats (3.6.2) quantile()
+    testList "Quantile.compute" [
+
+        testCase "testSeq" <| fun () ->
+            let expected = expectedShort
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.compute x testSeq1
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 8 expected actual "Quantiles should be equal"
+
+        testCase "testList" <| fun () ->
+            let expected = expectedShort
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.compute x testList1
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 8 expected actual "Quantiles should be equal"
+
+        testCase "testArray" <| fun () ->
+            let expected = expectedShort
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.compute x testArray1
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 8 expected actual "Quantiles should be equal"
+
+        testCase "testArrayLong" <| fun () ->
+            let expected = expected8
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.compute x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "testArrayNaN" <| fun () ->
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.compute x testArrayNaN
+                    )
+            let checkNan = actual |> Array.map (fun k -> nan.Equals k)
+            let expected = Array.init 7 (fun t -> true)
+            Expect.sequenceEqual expected checkNan "Quantiles should be equal"
+        
+        testCase "testArrayDuplicates" <| fun () ->
+            let expected = [|nan; -0.5; 0.0; 0.0; 0.0; 100.0; nan|] //r type 8
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.compute x testArrayDuplicates
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+    ]
+    
+[<Tests>]
+let quantileTests =
+    //tested against R stats (3.6.2) quantile()
+    testList "Quantile" [
+        let rnd = System.Random(1)
+        let testArrayLong = Array.init 10000 (fun _ -> rnd.NextDouble())
+        let percentiles = [|-1.;0.;0.1;0.5;0.9;1.;1.1|]
+            
+        //Type=1; Inverse of empirical distribution function
+        let expected1 = [|nan;5.634874108e-05;9.657269255e-02;4.949744681e-01;8.972069658e-01;9.999589436e-01;nan|]
+        //Type=2; Similar to type 1 but with averaging at discontinuities.
+        let expected2 = [|nan;5.634874108e-05;9.664607728e-02;4.950177730e-01;8.972569624e-01;9.999589436e-01;nan|]
+        //Type=3; SAS definition: nearest even order statistic
+        let expected3 = [|nan;5.634874108e-05;9.657269255e-02;4.949744681e-01;8.972069658e-01;9.999589436e-01;nan|]
+        //Type=4; linear interpolation of the empirical cdf.
+        let expected4 = [|nan;5.634874108e-05;9.657269255e-02;4.949744681e-01;8.972069658e-01;9.999589436e-01;nan|]
+        //Type=5; That is a piecewise linear function where the knots are the values midway through the steps of the empirical cdf
+        let expected5 = [|nan;5.634874108e-05;9.664607728e-02;4.950177730e-01;8.972569624e-01;9.999589436e-01;nan|]
+        //Type=6; This is used by Minitab and by SPSS
+        let expected6 = [|nan;5.634874108e-05;9.658736950e-02;4.950177730e-01;8.972969598e-01;9.999589436e-01;nan|]
+        //Type=7; This is used by S
+        let expected7 = [|nan;5.634874108e-05;9.670478506e-02;4.950177730e-01;8.972169651e-01;9.999589436e-01;nan|]
+        //Type=8; The resulting quantile estimates are approximately median-unbiased regardless of the distribution of x
+        let expected8 = [|nan;5.634874108e-05;9.662650802e-02;4.950177730e-01;8.972702949e-01;9.999589436e-01;nan|]
+        //Type=9; The resulting quantile estimates are approximately unbiased for the expected order statistics if x is normally distributed.
+        let expected9 = [|nan;5.634874108e-05;9.663140033e-02;4.950177730e-01;8.972669618e-01;9.999589436e-01;nan|]
+            
+        testCase "empiricalInvCdf" <| fun () ->
+            let expected = expected1
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.empiricalInvCdf x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "empiricalInvCdfAverage" <| fun () ->
+            let expected = expected2
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.empiricalInvCdfAverage x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "nearest" <| fun () ->
+            let expected = expected3
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.nearest x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "nist" <| fun () ->
+            let expected = expected6
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.nist x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "mode" <| fun () ->
+            let expected = expected7
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.mode x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "normal" <| fun () ->
+            let expected = expected9
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.normal x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+    ]
+
+
+
+[<Tests>]
+let quantileOfSortedTests =
+    //tested against R stats (3.6.2) quantile()
+    testList "Quantile.OfSorted" [
+
+        testCase "empiricalInvCdf" <| fun () ->
+            let expected = expected1
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.empiricalInvCdf x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "empiricalInvCdfAverage" <| fun () ->
+            let expected = expected2
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.empiricalInvCdfAverage x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "nearest" <| fun () ->
+            let expected = expected3
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.nearest x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "nist" <| fun () ->
+            let expected = expected6
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.nist x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "mode" <| fun () ->
+            let expected = expected7
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.mode x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+
+        testCase "normal" <| fun () ->
+            let expected = expected9
+            let actual = 
+                percentiles
+                |> Array.map (fun x -> 
+                    Quantile.normal x testArrayLong
+                    )
+            TestExtensions.sequenceEqualRoundedNaN 10 expected actual "Quantiles should be equal"
+    ]

--- a/tests/FSharp.Stats.Tests/TestExtensions.fs
+++ b/tests/FSharp.Stats.Tests/TestExtensions.fs
@@ -7,3 +7,15 @@ let sequenceEqualRounded (digits : int) actual expected message =
     let round (v:float) = System.Math.Round(v,digits)
     Expect.sequenceEqual (actual |> Seq.map round) (expected |> Seq.map round) message
 
+/// Expects the `actual` sequence to equal the `expected` one after rounding the floats in both to the given digit count (nans are checked)
+let sequenceEqualRoundedNaN (digits : int) actual expected message =
+    let round (v:float) = System.Math.Round(v,digits)
+    Seq.iter2 (fun a b -> 
+        if nan.Equals a then 
+            Expect.isTrue (nan.Equals b) message
+        else 
+            Expect.equal (round a) (round b) message
+        ) 
+        actual 
+        expected
+


### PR DESCRIPTION
Two changes:

1. Based on @bvenn's great [insight](https://github.com/fslaborg/FSharp.Stats/issues/190#issuecomment-1084768251) that the OfSorted quantile functions are fast this, PR improves performance of Quantile.compute (and others) by internally first using Array.sortInPlace on the input and then passing that to the OfSorted versions. Is there any reason not to do this? (fixes #190)
2. Allow the Quantile.compute and similar functions to take a sequence input  (fixes #186)

**Description**

With this build:
```fsharp
open FSharp.Stats

let testArray = Array.append (Array.init 10_000_000 (fun _ -> 0.0)) [|1.0; nan|]
#time "on"
Quantile.compute 0.5 testArray 
// Real: 00:00:00.264, CPU: 00:00:00.312, GC gen0: 0, gen1: 0, gen2: 0

let rnd = System.Random()
let testArrayRand= Array.init 10_000_000 (fun _ -> rnd.NextDouble())

Quantile.compute 0.5 testArrayRand 
// Real: 00:00:01.094, CPU: 00:00:01.140, GC gen0: 0, gen1: 0, gen2: 0
```

**[Required]** please make sure you checked that
 - [X] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
