### PR TITLE
Fixes for Gamma.incompleteUpper

### DIFF
--- a/src/FSharp.Stats/SpecialFunctions/Gamma.fs
+++ b/src/FSharp.Stats/SpecialFunctions/Gamma.fs
@@ -158,13 +158,13 @@ module Gamma =
         let ASWITCH=100.
         //if (x < 0.0 || a <= 0.0) then failwith ("bad args in gammp")
         match x with
-        | x when x = 0. -> 0.
+        | x when x = 0. -> 1.
         | x when (x < 0.0 || a <= 0.0) -> nan
-        | x when (isPosInf x) -> 1.
+        | x when (isPosInf x) -> 0.
         | _ -> 
-            if (x= 0.0) then 0.0
+            if (x= 0.0) then 1.0
             elif (a >= ASWITCH) then
-                gammpapprox a x true
+                1.0 - gammpapprox a x true
 
             elif (x < a+1.0) then 1.0 - gser a x
             else gcf a x

--- a/tests/FSharp.Stats.Tests/SpecialFunctions.fs
+++ b/tests/FSharp.Stats.Tests/SpecialFunctions.fs
@@ -44,7 +44,7 @@ let gammaFunctionsTests =
 
         testCase "test_gammaincupperinf" <| fun () ->
             let gam = Gamma.upperIncomplete 0.5 Ops.inf
-            Expect.equal gam 1.0 "Should be equal"
+            Expect.equal gam 0.0 "Should be equal"
 
     ]    
 


### PR DESCRIPTION
**Please reference the issue(s) this PR is related to**

The problem is described [here](https://github.com/fslaborg/FSharp.Stats/issues/195)

Fixes #195 

**Please list the changes introduced in this PR**

- When x is 0, upperGamma should output 1
- When x is inf, upperGamma should output 0
- When a >= ASWITCH, the output (call it y) was identical to that of lowerIncomplete; it should've instead be 1 - y
- Test called `"test_gammaincupperinf"` now checks that upperGamma evaluates to 0 when the second argument is infinite (before the test wrongly asserted this result should be 1).

**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
I didn't add any new tests besides fixing the one mentioned above, but I checked that the results of upperGamma agree with an implementation in another language.