### PR TITLE
Add nullspace accuracy parameter

### DIFF
--- a/tests/FSharp.Stats.Tests/Main.fs
+++ b/tests/FSharp.Stats.Tests/Main.fs
@@ -18,7 +18,8 @@ let main argv =
     
     //================================ Algebra ==============================================================
     Tests.runTestsWithCLIArgs [] argv LinearAlgebraTests.managedSVDTests   |> ignore
-
+    Tests.runTestsWithCLIArgs [] argv LinearAlgebraTests.nullspace         |> ignore
+    
     //================================== List ===============================================================
     Tests.runTestsWithCLIArgs [] argv ListTests.medianTests |> ignore
     Tests.runTestsWithCLIArgs [] argv ListTests.meanTests   |> ignore


### PR DESCRIPTION
**Related issue**

closes #194

**Please list the changes introduced in this PR**

- remove LinearAlgebraService requirement for nullspace calculation
- add optional accuracy parameter for matrix rank determination

**Description**

The accuracy parameter defines the threshold that separates zero singular values from nonzero ones. The default threshold is set to `1e-08`. 

```f#
let a = matrix [[..]
let ns = LinearAlgebra.nullspace(Accuracy=1e-10)
let product = a * ns
//product should give matrix of zeros`
```




**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
