### PR TITLE
Update rank module

### DIFF
--- a/FSharp.Stats.sln
+++ b/FSharp.Stats.sln
@@ -37,8 +37,6 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "build", "build\build.fsproj
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{23F9FB2E-6804-4AF9-B6D5-5CBD00E14A02}"
 	ProjectSection(SolutionItems) = preProject
-		docs\_template.html = docs\_template.html
-		docs\_template.ipynb = docs\_template.ipynb
 		docs\BasicStats.fsx = docs\BasicStats.fsx
 		docs\Clustering.fsx = docs\Clustering.fsx
 		docs\ComparisonMetrics.fsx = docs\ComparisonMetrics.fsx
@@ -59,7 +57,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{23F9FB2E-6
 		docs\Matrix_Vector.fsx = docs\Matrix_Vector.fsx
 		docs\NuGet.config = docs\NuGet.config
 		docs\Signal.fsx = docs\Signal.fsx
+		docs\Rank.fsx = docs\Rank.fsx
 		docs\Testing.fsx = docs\Testing.fsx
+		docs\_template.html = docs\_template.html
+		docs\_template.ipynb = docs\_template.ipynb
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{50E3E339-AA4D-4FD2-8791-DEBD2EBF0504}"

--- a/docs/Rank.fsx
+++ b/docs/Rank.fsx
@@ -1,0 +1,122 @@
+(**
+---
+title: Ranking
+index: 18
+category: Documentation
+categoryindex: 0
+---
+*)
+
+(*** hide ***)
+
+(*** condition: prepare ***)
+#I "../src/FSharp.Stats/bin/Release/netstandard2.0/"
+#r "FSharp.Stats.dll"
+#r "nuget: Plotly.NET, 2.0.0-preview.16"
+
+(*** condition: ipynb ***)
+#if IPYNB
+#r "nuget: Plotly.NET, 2.0.0-preview.16"
+#r "nuget: Plotly.NET.Interactive, 2.0.0-preview.16"
+#r "nuget: FSharp.Stats"
+#endif // IPYNB
+
+
+open Plotly.NET
+open Plotly.NET.StyleParam
+open Plotly.NET.LayoutObjects
+
+//some axis styling
+module Chart = 
+    let myAxis name = LinearAxis.init(Title=Title.init name,Mirror=StyleParam.Mirror.All,Ticks=StyleParam.TickOptions.Inside,ShowGrid=false,ShowLine=true)
+    let myAxisRange name (min,max) = LinearAxis.init(Title=Title.init name,Range=Range.MinMax(min,max),Mirror=StyleParam.Mirror.All,Ticks=StyleParam.TickOptions.Inside,ShowGrid=false,ShowLine=true)
+    let withAxisTitles x y chart = 
+        chart 
+        |> Chart.withTemplate ChartTemplates.lightMirrored
+        |> Chart.withXAxis (myAxis x) 
+        |> Chart.withYAxis (myAxis y)
+
+(**
+
+# Ranking
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fslaborg/FSharp.Stats/gh-pages?filepath=Rank.ipynb)
+
+_Summary:_ this tutorial demonstrates how to determine ranks of a collection
+
+Consider a collection of values. The rank of a number is its size relative to other values in a sequence.
+There are four methods how to handle ties:
+
+
+```
+let mySequence = [|1.0; -2.0; 0.0; 1.0|]
+```
+
+- **rankFirst**
+  - Each rank occurs exactly once. If ties are present the first occurence gets the low rank. 
+  - ATTENTION: If there are multiple ties (>20) the sorting of Arrays will not preserve the element order correctly!!
+  - `ranks = [3,1,2,4]`
+
+
+- **rankMin**
+  - If ties are present all tied elements receive the score of the first occurence (min rank)
+  - `ranks = [3,1,2,3]`
+
+- **rankMax**
+  - If ties are present all tied elements receive the score of the last occurence (max rank)
+  - `ranks = [4,1,2,4]`
+
+
+- **rankAverge**
+  - If ties are present all tied elements receive their average rank.
+  - `ranks = [3.5,1,2,3.5]`
+
+
+## NaN treatment
+If nans are present in the collection, there are several ways to treat them. In general `nan <> nan` so that each occurence will receive its unique rank. 
+(for infinity and -infinity the equality check returns true).
+  
+  - Usually nans are sorted to the beginning of the collection: `nan, -infinity, -100., 0., 100, infinity`
+  - By default in FSharp.Stats.Rank, nans are sorted to the end of the sequence (the sorting can be defined as optional parameter)
+  - Additionally ranks of nan values are set to nan if not specified othwerwise
+*)
+
+open FSharp.Stats
+
+let collection = [|2.;-infinity;infinity;infinity;nan;0|]
+
+Rank.RankFirst() collection
+// result:  [|3.0; 1.0; 4.0; 5.0; nan; 2.0|]
+
+Rank.RankMin() collection
+// result:  [|3.0; 1.0; 4.0; 4.0; nan; 2.0|]
+
+Rank.RankMax() collection
+// result:  [|3.0; 1.0; 5.0; 5.0; nan; 2.0|]
+
+Rank.RankAverage() collection
+// result:  [|3.0; 1.0; 4.5; 4.5; nan; 2.0|]
+
+(**
+
+
+If you want to preserve the true ranks of nans but sort them to the back you can use:
+
+*)
+
+Rank.RankFirst(RankNanWithNan=false) collection
+// result:  [|3.0; 1.0; 4.0; 5.0; 6.0; 2.0|]
+
+
+(**
+
+
+If you want to preserve the true ranks of nans AND sort them to the beginning you can use:
+
+*)
+
+Rank.RankFirst(NanIsMaximum=false,RankNanWithNan=false) collection
+// result:  [|4.0; 2.0; 5.0; 6.0; 1.0; 3.0|]
+
+
+

--- a/src/FSharp.Stats/Correlation.fs
+++ b/src/FSharp.Stats/Correlation.fs
@@ -213,8 +213,8 @@ module Correlation =
         /// </example>
         let inline spearman (seq1: seq<'T>) (seq2: seq<'T>) : float =
     
-            let spearRank1 = seq1 |> Seq.map float |> Seq.toArray |> FSharp.Stats.Rank.rankAverage
-            let spearRank2 = seq2 |> Seq.map float |> Seq.toArray |> FSharp.Stats.Rank.rankAverage
+            let spearRank1 = seq1 |> Seq.map float |> Seq.toArray |> FSharp.Stats.Rank.RankAverage()
+            let spearRank2 = seq2 |> Seq.map float |> Seq.toArray |> FSharp.Stats.Rank.RankAverage()
 
             pearson spearRank1 spearRank2
 
@@ -304,7 +304,7 @@ module Correlation =
                 
                 loop 0 1 0.0 0.0 0.0 0.0 0.0
 
-            kendallCorrFun (FSharp.Stats.Rank.rankFirst setA ) (FSharp.Stats.Rank.rankFirst setB )
+            kendallCorrFun (FSharp.Stats.Rank.RankFirst() setA ) (FSharp.Stats.Rank.RankFirst() setB )
 
         /// <summary>
         /// Calculates the kendall correlation coefficient of two samples given as a sequence of paired values. 

--- a/src/FSharp.Stats/Fitting/QuantileNormalization.fs
+++ b/src/FSharp.Stats/Fitting/QuantileNormalization.fs
@@ -24,7 +24,7 @@ module QuantileNormalization =
         let rawRanks = 
             colSeq
             |> Seq.map (fun col -> 
-                let colRank = Rank.rankAverage col
+                let colRank = Rank.RankAverage() col
                 col |> Array.mapi (fun i v -> colRank.[i],v)
                 ) 
                     

--- a/src/FSharp.Stats/Rank.fs
+++ b/src/FSharp.Stats/Rank.fs
@@ -1,26 +1,46 @@
 ﻿namespace FSharp.Stats
 
-
-/// Module to Calculate the rank. The rank of a number is its size relative to other values in a sequence
 module Rank =
 
-    /// Ranks each entry of the given unsorted data array. Use 'breakTies function to break ties
-    let inline private rank (breakTies: int -> int -> 'b) (convert: int -> 'b) (data:array<'a>) : array<'b> =
-        let zero = LanguagePrimitives.GenericZero< 'b > 
-        //let ranks  = Array.copy data
-        let data' = Array.copy data
-        let ranks  = Array.create data.Length zero
-        let index = Array.init data.Length id
-        System.Array.Sort(data',index)
+    /// Comparer that sorts nan at the end of a collection
+    let inline internal compNaNLast<'T when 'T :> System.IComparable> =
+        //if typeof<'T>.Name="Double"
+        let comparison = 
+            System.Comparison(fun (a : 'T when 'T :> System.IComparable) b -> 
+                if nan.Equals(a) then 
+                    1//if nan.Equals(b) then 0 else 1 
+                elif nan.Equals(b) then 
+                    -1
+                else 
+                    System.Collections.Generic.Comparer.Default.Compare(a,b)
+            )
+        System.Collections.Generic.Comparer<'T>.Create(comparison)
 
+    /// Comparer that sorts nan at the start of a collection
+    let inline internal compNaNFirst<'U when 'U :> System.IComparable> = 
+        System.Collections.Generic.Comparer.Default
+        
+    /// Ranks each entry of the given unsorted data array. Use 'breakTies function to break ties
+    let inline internal rank (breakTies: int -> int -> float) (convert: int -> float) (comparer: System.Collections.Generic.Comparer<'b>) (rankNanWithNan: bool) (data:'a []) : float [] =
+        let data' = Array.copy data
+        let ranks = Array.zeroCreate data.Length
+        let index = Array.init data.Length id
+        //let zero  = LanguagePrimitives.GenericZero< 'a >
+        //let comparer,rankNanWithNan = if box zero :? float then comparer,rankNanWithNan else (compNaNFirst,false)
+        let comparer,rankNanWithNan = if typeof<'a>.Name = "Double" then comparer,rankNanWithNan else (compNaNFirst,false)
+        System.Array.Sort(data',index,comparer=comparer)
+        
         let setTies a b =
             let tmp = breakTies a b
             for j = a to b-1 do
                 ranks.[index.[j]] <- tmp
-
+        
         let rec loop i pi =
             if i < data.Length then
-                if (abs (data'.[i] - data'.[pi]) = zero) then
+                if rankNanWithNan && nan.Equals(data'.[pi]) then        //new
+                    ranks.[index.[pi]] <- nan                           //new
+                    loop (i+1) i                                        //new
+                elif data'.[i] = data'.[pi] then
                     loop (i+1) pi
                 else
                     if (i = pi + 1) then
@@ -28,53 +48,90 @@ module Rank =
                     else
                         //break ties
                         setTies pi i
-
+        
                     loop (i+1) (i)
             else
                 //break ties if left over                
                 //setTies pi i
                 if (i = pi + 1) then
-                    ranks.[index.[pi]] <- convert i
+                    if rankNanWithNan && nan.Equals(data'.[pi]) then    //new
+                        ranks.[index.[pi]] <- nan                       //new
+                        ()                                              //new 
+                    else 
+                        ranks.[index.[pi]] <- convert i
                 else
                     //break ties
                     setTies pi i
-
+        
         loop 1 0 |> ignore
         ranks
+        
 
+open System
+open Rank
 
+/// The rank of a number is its size relative to other values in a sequence
+type Rank() = 
     /// Ranks each entry of the given unsorted data array.
-    /// Permutation with increasing values at each index of ties.
-    let inline rankFirst (data:array<_>) =
-        //let ranks  = Array.copy data
-        let data' = Array.copy data
-        let ranks  = Array.create data.Length 0.
-        let index = Array.init data.Length id
-        System.Array.Sort(data',index)
-
-        for i=0 to ranks.Length-1 do
-            ranks.[index.[i]] <- float (i + 1)
-
-        ranks
-
-
+    /// Permutation with increasing values at each index of ties. Nans can be sorted as minimal or maximal values (default: maximal). Nans can be assigned to nan ranks (default: true)
+    static member RankFirst(?NanIsMaximum,?RankNanWithNan) =
+        let orderNanLast = defaultArg NanIsMaximum true
+        let setNanToNan = defaultArg RankNanWithNan true
+        fun (data:array<'b>) -> 
+            let data' = Array.copy data
+            //let comparer = if ties then compNaNLast else compNaNFirst
+            let ranks  = Array.zeroCreate data.Length
+            let index = Array.init data.Length id
+            //System.Array.Sort(data',index,comparer=comparer)
+            
+            if orderNanLast then System.Array.Sort(data',index,comparer=compNaNLast) else System.Array.Sort(data',index)
+            if setNanToNan && typeof<'b>.Name = "Double" then 
+                for i=0 to ranks.Length-1 do
+                    if nan.Equals data.[index.[i]] then 
+                        ranks.[index.[i]] <- nan
+                    else
+                        ranks.[index.[i]] <- float (i + 1)
+            else 
+                for i=0 to ranks.Length-1 do
+                    ranks.[index.[i]] <- float (i + 1)
+                
+            ranks
+            
     /// Ranks each entry of the given unsorted data array.
-    /// Ties are replaced by their minimum  
-    let inline rankMin (data:array<_>) =    
-        //let one = LanguagePrimitives.GenericOne< 'b > 
+    /// Ties are replaced by their minimum. Nans can be sorted as minimal or maximal values (default: maximal). Nans can be assigned to nan ranks (default: true)
+    static member RankMin(?NanIsMaximum,?RankNanWithNan) =
+        let orderNanLast = defaultArg NanIsMaximum true
+        let setNanToNan = defaultArg RankNanWithNan true
+        let comparer = if orderNanLast then compNaNLast else compNaNFirst
         let minTies a _ =  (float a + 1.)
-        rank minTies float data
-
+        
+        //fun (data:'T[] when 'T :> System.IComparable and ^T : (static member get_Zero : ^T))  -> 
+        fun (data)  -> 
+            rank minTies float comparer setNanToNan data
+            
 
     /// Ranks each entry of the given unsorted data array.
-    /// Ties are replaced by their maximum  
-    let inline rankMax (data:array<_>) =    
+    /// Ties are replaced by their maximum. Nans can be sorted as minimal or maximal values (default: maximal). Nans can be assigned to nan ranks (default: true)
+    static member RankMax(?NanIsMaximum,?RankNanWithNan) =
+        let orderNanLast = defaultArg NanIsMaximum true
+        let setNanToNan = defaultArg RankNanWithNan true
+        let comparer = if orderNanLast then compNaNLast else compNaNFirst
         let maxTies _ b = float b
-        rank maxTies float data
 
+        fun (data:array<_>) -> 
+            rank maxTies float comparer setNanToNan data
 
     /// Ranks each entry of the given unsorted data array.
-    /// Ties are replaced by their mean
-    let inline rankAverage (data:array<_>) =    
+    /// Ties are replaced by ther average ranks. Nans can be sorted as minimal or maximal values (default: maximal). Nans can be assigned to nan ranks (default: true)
+    static member RankAverage(?NanIsMaximum,?RankNanWithNan) =
+        let orderNanLast = defaultArg NanIsMaximum true
+        let setNanToNan = defaultArg RankNanWithNan true
+        let comparer = if orderNanLast then compNaNLast else compNaNFirst
         let averageTies a b = float (a + b + 1) / 2.//([(a + 1) .. b] |> List.sum) / float (b - a)
-        rank averageTies float data
+        
+        fun (data:array<_>) -> 
+            rank averageTies float comparer setNanToNan data
+
+
+
+

--- a/src/FSharp.Stats/Rank.fs
+++ b/src/FSharp.Stats/Rank.fs
@@ -132,6 +132,14 @@ type Rank() =
         fun (data:array<_>) -> 
             rank averageTies float comparer setNanToNan data
 
+    [<Obsolete("Use Rank.RankAverage() instead")>]
+    static member rankAverage = fun (x: float[]) -> Rank.RankAverage(false,false) x
+    [<Obsolete("Use Rank.RankFirst() instead")>] 
+    static member rankFirst = fun (x: float[]) -> Rank.RankFirst(false,false) x |> Array.map int
+    [<Obsolete("Use Rank.RankMin() instead")>]
+    static member rankMin = fun (x: float[]) -> Rank.RankMin(false,false) x
+    [<Obsolete("Use Rank.RankMax() instead")>]
+    static member rankMax = fun (x: float[]) -> Rank.RankMax(false,false) x
 
 
 

--- a/src/FSharp.Stats/Testing/FriedmanTest.fs
+++ b/src/FSharp.Stats/Testing/FriedmanTest.fs
@@ -20,7 +20,7 @@ module FriedmanTest =
         // rank all groups individually
         let ranksAll = 
             samples
-            |> Seq.map Rank.rankAverage
+            |> Seq.map (Rank.RankAverage())
 
         // get every first, second, third,...., value for ranking 
         let groups = 

--- a/src/FSharp.Stats/Testing/HTest.fs
+++ b/src/FSharp.Stats/Testing/HTest.fs
@@ -25,7 +25,7 @@ module HTest =
     
         // associating ranks to each element
         let valuesAndRanks = 
-            let ranks = Rank.rankAverage allElements
+            let ranks = Rank.RankAverage() allElements
             Array.zip allElements ranks 
     
         // match ranks with each group 

--- a/src/FSharp.Stats/Testing/Wilcoxon.fs
+++ b/src/FSharp.Stats/Testing/Wilcoxon.fs
@@ -16,7 +16,7 @@ module WilcoxonTest =
         // ranking with average for ties 
         let absolutevalueneg x = x * -1.
         let abs = Seq.append pos (Seq.map absolutevalueneg neg) |> Seq.toArray
-        let ranks = Rank.rankAverage abs
+        let ranks = Rank.RankAverage() abs
 
         // separating positive and negative values
         let lengthpos = Seq.length pos

--- a/tests/FSharp.Stats.Tests/Main.fs
+++ b/tests/FSharp.Stats.Tests/Main.fs
@@ -76,6 +76,9 @@ let main argv =
     //================================== Integration ============================================================
     Tests.runTestsWithCLIArgs [] argv IntegrationTests.numericalIntegrationTests      |> ignore
 
+    //================================== Integration ============================================================
+    Tests.runTestsWithCLIArgs [] argv RankTests.rankTests      |> ignore
+
     //================================== Quantile ============================================================
     Tests.runTestsWithCLIArgs [] argv QuantileTests.quantileDefaultTests  |> ignore
     Tests.runTestsWithCLIArgs [] argv QuantileTests.quantileTests         |> ignore

--- a/tests/FSharp.Stats.Tests/Rank.fs
+++ b/tests/FSharp.Stats.Tests/Rank.fs
@@ -7,23 +7,72 @@ open FSharp.Stats
 [<Tests>]
 let rankTests = 
     let arrayA = [|6.;6.;6.;1.;-2.;3.;3.;3.;3.;2.5;4.;-2.;0.;5.;1.|]
+    let arrayB = [|6;6;6;1;-2;3;3;3;3;2;4;-2;0;5;1|]
+    let arrayC = [|-infinity;nan;nan;1.;-2.;3.;3.;3.;infinity;2.5;infinity;-2.;0.;5.;1.|]
+    
+    let exFstA = [|13.;14.;15.;4.;1.;7.;8.;9.;10.;6.;11.;2.;3.;12.;5.|]
+    let exAvgA = [|14.;14.;14.;4.5;1.5;8.5;8.5;8.5;8.5;6.;11.;1.5;3.;12.;4.5|] 
+    let exMaxA = [|15.;15.;15.;5.;2.;10.;10.;10.;10.;6.;11.;2.;3.;12.;5.;|]
+    let exMinA = [|13.;13.;13.;4.;1.;7.;7.;7.;7.;6.;11.;1.;3.;12.;4.;|]
+    
+    //C default sorting
+    let exAvgCNanFirst = [|3.;1.;2.;7.5;4.5;11.;11.;11.;14.5;9.;14.5;4.5;6.;13.;7.5;|]
+    let exFstCNanFirst = [|3.;1.;2.;7.;4.;10.;11.;12.;14.;9.;15.;5.;6.;13.;8.;|]
+    let exMaxCNanFirst = [|3.;1.;2.;8.;5.;12.;12.;12.;15.;9.;15.;5.;6.;13.;8.;|]
+    let exMinCNanFirst = [|3.;1.;2.;7.;4.;10.;10.;10.;14.;9.;14.;4.;6.;13.;7.;|]
+    
+    //C nan last
+    let exAvgCNanLast = [|1.;14.;15.;5.5;2.5;9.;9.;9.;12.5;7.;12.5;2.5;4.;11.;5.5;|]
+    let exFstCNanLast = [|1.;14.;15.;5.;2.;8.;9.;10.;12.;7.;13.;3.;4.;11.;6.;|]
+    let exMaxCNanLast = [|1.;14.;15.;6.;3.;10.;10.;10.;13.;7.;13.;3.;4.;11.;6.;|]
+    let exMinCNanLast = [|1.;14.;15.;5.;2.;8.;8.;8.;12.;7.;12.;2.;4.;11.;5.;|]
 
-    let exAvg = [|14.0;14.0;14.0;4.5;1.5;8.5;8.5;8.5;8.5;6.0;11.0;1.5;3.0;12.0;4.5|]
-
-    let exFst = [|13.0;14.0;15.0;4.0;1.0;7.0;8.0;9.0;10.0;6.0;11.0;2.0;3.0;12.0;5.0|]
-
-    let exMax = [|15.0;15.0;15.0;5.0;2.0;10.0;10.0;10.0;10.0;6.0;11.0;2.0;3.0;12.0;5.0|]
-
-    let exMin = [|13.0;13.0;13.0;4.0;1.0;7.0;7.0;7.0;7.0;6.0;11.0;1.0;3.0;12.0;4.0|]
+    //C assign nan to nan ranks
+    let exAvgNanNan = [|1.;nan;nan;5.5;2.5;9.;9.;9.;12.5;7.;12.5;2.5;4.;11.;5.5;|]
+    let exFstNanNan = [|1.;nan;nan;5.;2.;8.;9.;10.;12.;7.;13.;3.;4.;11.;6.;|]
+    let exMaxNanNan = [|1.;nan;nan;6.;3.;10.;10.;10.;13.;7.;13.;3.;4.;11.;6.;|]
+    let exMinNanNan = [|1.;nan;nan;5.;2.;8.;8.;8.;12.;7.;12.;2.;4.;11.;5.;|]
 
     testList "Rank" [
-        testCase "rankAverage" <| fun () -> 
-            Expect.sequenceEqual (Rank.rankAverage arrayA) exAvg "ranks should be equal"
-        testCase "rankFirst" <| fun () -> 
-            Expect.sequenceEqual (Rank.rankFirst arrayA) exFst "ranks should be equal"
-        testCase "rankMax" <| fun () -> 
-            Expect.sequenceEqual (Rank.rankMax arrayA) exMax "ranks should be equal"
-        testCase "rankMin" <| fun () -> 
-            Expect.sequenceEqual (Rank.rankMin arrayA) exMin "ranks should be equal"
+        testCase "RankAverage" <| fun () -> 
+            Expect.sequenceEqual (Rank.RankAverage(false,false) arrayA) exAvgA "ranks should be equal"
+        testCase "RankFirst" <| fun () -> 
+            Expect.sequenceEqual (Rank.RankFirst(false,false) arrayA) exFstA "ranks should be equal"
+        testCase "RankMax" <| fun () -> 
+            Expect.sequenceEqual (Rank.RankMax(false,false) arrayA) exMaxA "ranks should be equal"
+        testCase "RankMin" <| fun () -> 
+            Expect.sequenceEqual (Rank.RankMin(false,false) arrayA) exMinA "ranks should be equal"
+        testCase "RankFirstInt" <| fun () -> 
+            Expect.sequenceEqual (Rank.RankFirst(false,false) arrayB) exFstA "ranks for ints should be equal"
+
+            
+        testCase "RankAverageNaNFirst" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1 (Rank.RankAverage(false,false) arrayC) exAvgCNanFirst "ranks should be equal"
+        testCase "RankFirstNaNFirst" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankFirst(false,false) arrayC) exFstCNanFirst "ranks should be equal"
+        testCase "RankMaxNaNFirst" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankMax(false,false) arrayC) exMaxCNanFirst "ranks should be equal"
+        testCase "RankMinNaNFirst" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankMin(false,false) arrayC) exMinCNanFirst "ranks should be equal"
+
+        testCase "RankAverageNaNLast" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankAverage(true,false) arrayC) exAvgCNanLast "ranks should be equal"
+        testCase "RankFirstNaNLast" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankFirst(true,false) arrayC) exFstCNanLast "ranks should be equal"
+        testCase "RankMaxNaNLast" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankMax(true,false) arrayC) exMaxCNanLast "ranks should be equal"
+        testCase "RankMinNaNLast" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankMin(true,false) arrayC) exMinCNanLast "ranks should be equal"
+
+        
+        testCase "RankAverageSetNanToNan" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankAverage(true,true) arrayC) exAvgNanNan "ranks should be equal"
+        testCase "RankFirstSetNanToNan" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankFirst(true,true) arrayC) exFstNanNan "ranks should be equal"
+        testCase "RankMaxSetNanToNan" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankMax(true,true) arrayC) exMaxNanNan "ranks should be equal"
+        testCase "RankMinSetNanToNan" <| fun () -> 
+            TestExtensions.TestExtensions.sequenceEqualRoundedNaN 1  (Rank.RankMin(true,true) arrayC) exMinNanNan "ranks should be equal"
+
     ]
 


### PR DESCRIPTION
Closes #183 


**Please list the changes introduced in this PR**

- add possibility to define the ranking of nan's
- add rank unit tests
- add rank documentation
- previous functions were tagged with _obsolete_ warnings

**Description**

For a detailed problem description checkout #183. 

I updated the rank module so that the result type for all tie-handling methods is `float []`. Additionally the processing of nans was changed severely. Nans are now sorted to the back of each collections and optionally can be assigned with nan ranks.


**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
