### PR TITLE
Fix infinite loop bug in X² CDF

### DIFF
--- a/src/FSharp.Stats/Distributions/Continuous.fs
+++ b/src/FSharp.Stats/Distributions/Continuous.fs
@@ -70,6 +70,7 @@ module Continuous =
             if dof = 0. then 
                 if x > 0. then 1.
                 else 0.
+            elif isNan x then nan
             else Gamma.lowerIncomplete (dof/2.) (x/2.)
 
         /// Returns the support of the exponential distribution: [0, Positive Infinity).


### PR DESCRIPTION
**Please reference the issue(s) this PR is related to**

Fixes #217 

**Please list the changes introduced in this PR**

- Bug fixed when using `ChiSquared.CDF` with arbitrary dof and x being `nan`

**Description**

When using the CDF in a ChiSquared distribution with input value `nan`, `Gamma.lowerIncomplete` resp. `gcf` goes into infinite loop.
CDF function now checks for input being `nan` and returning `nan` if so.

**[Required]** please make sure you checked that
 - [×] The project builds without problems on your machine _(and bugfix works, too)_

**[Optional]**
 - [ ] Added unit tests regarding the added features _(will be done in near future)_
