### PR TITLE
Addition of Vector.linspace

### DIFF
--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -507,19 +507,22 @@ module Array =
         array 
         |> Array.filter (System.Double.IsNaN >> not)
 
+[<AutoOpen>]
+module ArrayExtension =
+    type Array() =
 
-type Array() =
-
-    /// Creates an float array from an given interval.
-    /// start: start value (is included)
-    /// stop: end value (by default is included )
-    /// Num: sets the number of elements in the array. If not set, stepsize = 1.
-    /// IncludeEndpoint (default = true): If false, array does not contain stop value
-    static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float [] = 
+        /// <summary>
+        /// Creates an float array with values between a given interval
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included )</param>
+        /// <param name="Num">sets the number of elements in the array. If not set, stepsize = 1.</param>
+        /// <param name="IncludeEndpoint">If false, the array does not contain the stop value</param>
+        static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float [] = 
         
-        let includeEndpoint = defaultArg IncludeEndpoint true
+            let includeEndpoint = defaultArg IncludeEndpoint true
 
-        if Num.IsSome then 
-            Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Array.ofSeq
-        else 
-            Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Array.ofSeq
+            if Num.IsSome then 
+                Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Array.ofSeq
+            else 
+                Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Array.ofSeq

--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -507,3 +507,19 @@ module Array =
         array 
         |> Array.filter (System.Double.IsNaN >> not)
 
+
+type Array() =
+
+    /// Creates an float array from an given interval.
+    /// start: start value (is included)
+    /// stop: end value (by default is included )
+    /// Num: sets the number of elements in the array. If not set, stepsize = 1.
+    /// IncludeEndpoint (default = true): If false, array does not contain stop value
+    static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float [] = 
+        
+        let includeEndpoint = defaultArg IncludeEndpoint true
+
+        if Num.IsSome then 
+            Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Array.ofSeq
+        else 
+            Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Array.ofSeq

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -190,3 +190,19 @@ module List =
         list
         |> List.map f
         |> covOfPairs
+
+type List() =
+
+    /// Creates an list from an given interval.
+    /// start: start value (is included)
+    /// stop: end value (by default is included )
+    /// Num: sets the number of elements in the list. If not set, stepsize = 1.
+    /// IncludeEndpoint (default = true): If false, list does not contain stop value
+    static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float list = 
+        
+        let includeEndpoint = defaultArg IncludeEndpoint true
+
+        if Num.IsSome then 
+            Seq.linspace(start,stop,Num.Value,includeEndpoint) |> List.ofSeq
+        else 
+            Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> List.ofSeq

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -191,18 +191,23 @@ module List =
         |> List.map f
         |> covOfPairs
 
-type List() =
+[<AutoOpen>]
+module ListExtension =
 
-    /// Creates an list from an given interval.
-    /// start: start value (is included)
-    /// stop: end value (by default is included )
-    /// Num: sets the number of elements in the list. If not set, stepsize = 1.
-    /// IncludeEndpoint (default = true): If false, list does not contain stop value
-    static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float list = 
+    type List() =
+
+        /// <summary>
+        /// Creates an float list with values between a given interval
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included )</param>
+        /// <param name="Num">sets the number of elements in the list. If not set, stepsize = 1.</param>
+        /// <param name="IncludeEndpoint">If false, the list does not contain the stop value</param>
+        static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float list = 
         
-        let includeEndpoint = defaultArg IncludeEndpoint true
+            let includeEndpoint = defaultArg IncludeEndpoint true
 
-        if Num.IsSome then 
-            Seq.linspace(start,stop,Num.Value,includeEndpoint) |> List.ofSeq
-        else 
-            Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> List.ofSeq
+            if Num.IsSome then 
+                Seq.linspace(start,stop,Num.Value,includeEndpoint) |> List.ofSeq
+            else 
+                Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> List.ofSeq

--- a/src/FSharp.Stats/ML/Unsupervised/DbScan.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/DbScan.fs
@@ -2,7 +2,7 @@
 
 
 open System
-open System.Collections.Generic
+open System.Collections
 
 open FSharp.Stats
 
@@ -50,7 +50,7 @@ module DbScan =
             | :? array<'a> as value -> TaggedValue(value)
             | _ -> TaggedValue( input |> Seq.toArray )
 
-        let inline expandCluster dfu (point:TaggedValue<'a array>) (neighours:List<TaggedValue<'a array>>) (sourcelist:List<TaggedValue<'a array>>) (eps:float) (minPts:int) (cluster:List<TaggedValue<'a array>>)= 
+        let inline expandCluster dfu (point:TaggedValue<'a array>) (neighours:Generic.List<TaggedValue<'a array>>) (sourcelist:Generic.List<TaggedValue<'a array>>) (eps:float) (minPts:int) (cluster:Generic.List<TaggedValue<'a array>>)= 
             cluster.Add point                                                                        
             point.SetIsInCluster ()                                                                 
             let rec loop i =                                                                         
@@ -68,17 +68,17 @@ module DbScan =
                     loop (i+1)                                                                       
             loop 0 
 
-        let noiseList= List<TaggedValue<'a array>>()
-        let clusterList = List<List<TaggedValue<'a array>>>() 
+        let noiseList= Generic.List<TaggedValue<'a array>>()
+        let clusterList = Generic.List<Generic.List<TaggedValue<'a array>>>() 
     
-        let sourcelist = List (input |> Seq.map convert)
+        let sourcelist = Generic.List (input |> Seq.map convert)
                                                                                                             
         for i=0 to sourcelist.Count-1 do                                                                                               
             if not sourcelist.[i].IsVisited then                                        
                 sourcelist.[i].SetIsVisited ()
                 let neiOfI = sourcelist.FindAll (fun x -> dfu x.Value sourcelist.[i].Value <= eps)      
                 if neiOfI.Count >= minPts then                                        
-                    let c = List<TaggedValue<'a array>>()                                         
+                    let c = Generic.List<TaggedValue<'a array>>()                                         
                     expandCluster dfu sourcelist.[i] neiOfI sourcelist eps minPts c      
                     clusterList.Add c                                                
         let noisepoints =                                                            

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -1204,37 +1204,41 @@ module Seq =
             | :? ('T[]) as arr -> Array.copy arr
             | _ -> Seq.toArray xs
 
-type Seq() =
+[<AutoOpen>]
+module SeqExtension =
+    type Seq() =
 
-    /// Creates an seq<float> from an given interval.
-    /// start: start value (is included)
-    /// stop: end value (by default is included )
-    /// Num: sets the number of elements in the sequence. If not set, stepsize = 1.
-    /// IncludeEndpoint (default = true): If false, sequence does not contain stop value
-    static member inline linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : seq<float> = 
+        /// <summary>
+        /// Creates an seq<float> with values between a given interval
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included )</param>
+        /// <param name="Num">sets the number of elements in the seq. If not set, stepsize = 1.</param>
+        /// <param name="IncludeEndpoint">If false, the seq does not contain the stop value</param>
+        static member inline linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : seq<float> = 
         
-        let includeEndpoint = defaultArg IncludeEndpoint true
+            let includeEndpoint = defaultArg IncludeEndpoint true
 
-        if Num.IsSome then 
-            if includeEndpoint then 
-                let stepsize = (stop - start) / (float (Num.Value - 1))
-                Seq.init Num.Value (fun i -> stepsize * float i + start)
-            else 
-                let stepsize = (stop - start) / (float (Num.Value))
-                Seq.init Num.Value (fun i -> stepsize * float i + start)
+            if Num.IsSome then 
+                if includeEndpoint then 
+                    let stepsize = (stop - start) / (float (Num.Value - 1))
+                    Seq.init Num.Value (fun i -> stepsize * float i + start)
+                else 
+                    let stepsize = (stop - start) / (float (Num.Value))
+                    Seq.init Num.Value (fun i -> stepsize * float i + start)
                     
-        else 
-            if includeEndpoint then
-                let num = (stop - start) |> ceil
-                Seq.init (int num + 1) (fun i -> float i + start)
             else 
-                let dif = stop - start
-                let num = 
-                    if System.Math.Round dif = dif then 
-                        floor dif
-                    else 
-                        ceil dif
-                Array.init (int num) (fun i -> float i + start)
+                if includeEndpoint then
+                    let num = (stop - start) |> ceil
+                    Seq.init (int num + 1) (fun i -> float i + start)
+                else 
+                    let dif = stop - start
+                    let num = 
+                        if System.Math.Round dif = dif then 
+                            floor dif
+                        else 
+                            ceil dif
+                    Array.init (int num) (fun i -> float i + start)
 
 
 //    // ########################################################################

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -1204,6 +1204,39 @@ module Seq =
             | :? ('T[]) as arr -> Array.copy arr
             | _ -> Seq.toArray xs
 
+type Seq() =
+
+    /// Creates an seq<float> from an given interval.
+    /// start: start value (is included)
+    /// stop: end value (by default is included )
+    /// Num: sets the number of elements in the sequence. If not set, stepsize = 1.
+    /// IncludeEndpoint (default = true): If false, sequence does not contain stop value
+    static member inline linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : seq<float> = 
+        
+        let includeEndpoint = defaultArg IncludeEndpoint true
+
+        if Num.IsSome then 
+            if includeEndpoint then 
+                let stepsize = (stop - start) / (float (Num.Value - 1))
+                Seq.init Num.Value (fun i -> stepsize * float i + start)
+            else 
+                let stepsize = (stop - start) / (float (Num.Value))
+                Seq.init Num.Value (fun i -> stepsize * float i + start)
+                    
+        else 
+            if includeEndpoint then
+                let num = (stop - start) |> ceil
+                Seq.init (int num + 1) (fun i -> float i + start)
+            else 
+                let dif = stop - start
+                let num = 
+                    if System.Math.Round dif = dif then 
+                        floor dif
+                    else 
+                        ceil dif
+                Array.init (int num) (fun i -> float i + start)
+
+
 //    // ########################################################################
 //    /// A module which implements functional matrix operations.
 //    [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/src/FSharp.Stats/Vector.fs
+++ b/src/FSharp.Stats/Vector.fs
@@ -409,4 +409,17 @@ module VectorExtension =
         member x.Norm      = Vector.Generic.norm x
         member x.Copy ()   = Vector.Generic.copy x
 
+        /// Creates an vector from an given interval.
+        /// start: start value (is included)
+        /// stop: end value (by default is included )
+        /// Num: sets the number of elements in the vector. If not set, stepsize = 1.
+        /// IncludeEndpoint (default = true): If false, vector does not contain stop value
+        static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : vector = 
+        
+            let includeEndpoint = defaultArg IncludeEndpoint true
+
+            if Num.IsSome then 
+                Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Vector.ofSeq
+            else 
+                Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Vector.ofSeq
    

--- a/src/FSharp.Stats/Vector.fs
+++ b/src/FSharp.Stats/Vector.fs
@@ -409,11 +409,13 @@ module VectorExtension =
         member x.Norm      = Vector.Generic.norm x
         member x.Copy ()   = Vector.Generic.copy x
 
-        /// Creates an vector from an given interval.
-        /// start: start value (is included)
-        /// stop: end value (by default is included )
-        /// Num: sets the number of elements in the vector. If not set, stepsize = 1.
-        /// IncludeEndpoint (default = true): If false, vector does not contain stop value
+        /// <summary>
+        /// Creates an vector with values between a given interval
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included )</param>
+        /// <param name="Num">sets the number of elements in the vector. If not set, stepsize = 1.</param>
+        /// <param name="IncludeEndpoint">If false, the vector does not contain the stop value</param>
         static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : vector = 
         
             let includeEndpoint = defaultArg IncludeEndpoint true

--- a/tests/FSharp.Stats.Tests/Array.fs
+++ b/tests/FSharp.Stats.Tests/Array.fs
@@ -3,6 +3,7 @@
 open Expecto
 open System
 open FSharp.Stats
+open TestExtensions
 
 let testArrayEvenCounts = [|10000.;-0.1;14.;-10.|]
 let testArrayOddCounts = [|10000.;-0.1;14.;-10.;5.|]
@@ -48,4 +49,46 @@ let dropNanTests =
             let expected = [|-infinity; 0.5; 1.5; 1000.; 5.0|]
             let actual = Array.dropNaN testArray
             Expect.equal expected actual "Filtered array is incorrect"
+    ]
+
+   
+[<Tests>]
+let linspaceTests =
+    testList "Array" [
+        testCase "linspace_0" <| fun () ->
+            let expected = Array.linspace(-3.5,2.5)
+            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5; 2.5|]
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
+
+        testCase "linspace_1" <| fun () ->
+            let expected = Array.linspace(-3.5,2.5,IncludeEndpoint=false)
+            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5|]
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
+
+        testCase "linspace_2" <| fun () ->
+            let expected = Array.linspace(-3.5,2.1)
+            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5; 2.5|]
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
+        
+        testCase "linspace_3" <| fun () ->
+            let expected = Array.linspace(-3.5,2.1,IncludeEndpoint=false)
+            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5|]
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
+        
+        testCase "linspace_4" <| fun () ->
+            let expected = Array.linspace(-3.5,30.1,Num=7)
+            let actual = [|-3.5; 2.1; 7.7; 13.3; 18.9; 24.5; 30.1|]
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
+        
+        testCase "linspace_5" <| fun () ->
+            let expected = Array.linspace(-3.5,2.9,Num=17)
+            let actual = [|-3.5; -3.1; -2.7; -2.3; -1.9; -1.5; -1.1; -0.7; -0.3;  0.1;  0.5; 0.9;  1.3;  1.7;  2.1;  2.5;  2.9|]
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
+        
+        testCase "linspace_6" <| fun () ->
+            let expected = Array.linspace(-3.5,30.1,Num=6,IncludeEndpoint=false)
+            let actual = [|-3.5;  2.1;  7.7; 13.3; 18.9; 24.5|]
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
+      
+        
     ]

--- a/tests/FSharp.Stats.Tests/Main.fs
+++ b/tests/FSharp.Stats.Tests/Main.fs
@@ -35,6 +35,7 @@ let main argv =
     //================================== Array ==============================================================
     Tests.runTestsWithCLIArgs [] argv ArrayTests.medianTests   |> ignore
     Tests.runTestsWithCLIArgs [] argv ArrayTests.dropNanTests   |> ignore
+    Tests.runTestsWithCLIArgs [] argv ArrayTests.linspaceTests   |> ignore
 
     //================================== Interval ===========================================================
     Tests.runTestsWithCLIArgs [] argv IntervalTests.intervalTests   |> ignore


### PR DESCRIPTION
Fixes #235 

**Please list the changes introduced in this PR**

- add generic `Seq.linspace`
- add `Vector.linspace`
- add `Array.linspace`
- add `List.linspace`
- add tests

**Description**

I've added Vector.linspace as discussed in #235. 

**Note**: If no sequence length  is defined, numpy uses [50](https://numpy.org/doc/stable/reference/generated/numpy.linspace.html) as default. I thought it would be more intuitive, if the stepsize is set to 1.0 if no length is defined.


**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
