### PR TITLE
Addition of Geomspace

### DIFF
--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -526,3 +526,17 @@ module ArrayExtension =
                 Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Array.ofSeq
             else 
                 Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Array.ofSeq
+
+        /// <summary>
+        /// Creates a geometric array of floats with values between a given interval
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included)</param>
+        /// <param name="Num">sets the number of elements in the array. Defaults to 50.</param>
+        /// <param name="IncludeEndpoint">If false, the array does not contain the stop value. Defaults to true.</param>
+        static member geomspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float array = 
+            let includeEndpoint = defaultArg IncludeEndpoint true
+            let num = defaultArg Num 50
+
+            Seq.geomspace (start, stop ,num, includeEndpoint)
+            |> Array.ofSeq

--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -518,14 +518,11 @@ module ArrayExtension =
         /// <param name="stop">end value (by default is included )</param>
         /// <param name="Num">sets the number of elements in the array. If not set, stepsize = 1.</param>
         /// <param name="IncludeEndpoint">If false, the array does not contain the stop value</param>
-        static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float [] = 
+        static member linspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : float [] = 
         
             let includeEndpoint = defaultArg IncludeEndpoint true
 
-            if Num.IsSome then 
-                Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Array.ofSeq
-            else 
-                Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Array.ofSeq
+            Seq.linspace(start,stop,num,includeEndpoint) |> Array.ofSeq
 
         /// <summary>
         /// Creates a geometric array of floats with values between a given interval
@@ -534,9 +531,8 @@ module ArrayExtension =
         /// <param name="stop">end value (by default is included)</param>
         /// <param name="Num">sets the number of elements in the array. Defaults to 50.</param>
         /// <param name="IncludeEndpoint">If false, the array does not contain the stop value. Defaults to true.</param>
-        static member geomspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float array = 
+        static member geomspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : float array = 
             let includeEndpoint = defaultArg IncludeEndpoint true
-            let num = defaultArg Num 50
 
             Seq.geomspace (start, stop ,num, includeEndpoint)
             |> Array.ofSeq

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -211,3 +211,18 @@ module ListExtension =
                 Seq.linspace(start,stop,Num.Value,includeEndpoint) |> List.ofSeq
             else 
                 Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> List.ofSeq
+
+        /// <summary>
+        /// Creates a geometric list of floats with values between a given interval
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included)</param>
+        /// <param name="Num">sets the number of elements in the list. Defaults to 50.</param>
+        /// <param name="IncludeEndpoint">If false, the list does not contain the stop value. Defaults to true.</param>
+        static member geomspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float list = 
+            let includeEndpoint = defaultArg IncludeEndpoint true
+            let num = defaultArg Num 50
+
+            Seq.geomspace (start, stop ,num, includeEndpoint)
+            |> List.ofSeq
+

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -203,14 +203,11 @@ module ListExtension =
         /// <param name="stop">end value (by default is included )</param>
         /// <param name="Num">sets the number of elements in the list. If not set, stepsize = 1.</param>
         /// <param name="IncludeEndpoint">If false, the list does not contain the stop value</param>
-        static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float list = 
+        static member linspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : float list = 
         
             let includeEndpoint = defaultArg IncludeEndpoint true
 
-            if Num.IsSome then 
-                Seq.linspace(start,stop,Num.Value,includeEndpoint) |> List.ofSeq
-            else 
-                Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> List.ofSeq
+            Seq.linspace(start,stop,num,includeEndpoint) |> List.ofSeq
 
         /// <summary>
         /// Creates a geometric list of floats with values between a given interval
@@ -219,9 +216,8 @@ module ListExtension =
         /// <param name="stop">end value (by default is included)</param>
         /// <param name="Num">sets the number of elements in the list. Defaults to 50.</param>
         /// <param name="IncludeEndpoint">If false, the list does not contain the stop value. Defaults to true.</param>
-        static member geomspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : float list = 
+        static member geomspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : float list = 
             let includeEndpoint = defaultArg IncludeEndpoint true
-            let num = defaultArg Num 50
 
             Seq.geomspace (start, stop ,num, includeEndpoint)
             |> List.ofSeq

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -1215,30 +1215,17 @@ module SeqExtension =
         /// <param name="stop">end value (by default is included )</param>
         /// <param name="Num">sets the number of elements in the seq. If not set, stepsize = 1.</param>
         /// <param name="IncludeEndpoint">If false, the seq does not contain the stop value</param>
-        static member inline linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : seq<float> = 
+        static member inline linspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : seq<float> = 
         
             let includeEndpoint = defaultArg IncludeEndpoint true
 
-            if Num.IsSome then 
-                if includeEndpoint then 
-                    let stepsize = (stop - start) / (float (Num.Value - 1))
-                    Seq.init Num.Value (fun i -> stepsize * float i + start)
-                else 
-                    let stepsize = (stop - start) / (float (Num.Value))
-                    Seq.init Num.Value (fun i -> stepsize * float i + start)
-                    
+            if includeEndpoint then 
+                let stepsize = (stop - start) / (float (num - 1))
+                Seq.init num (fun i -> stepsize * float i + start)
             else 
-                if includeEndpoint then
-                    let num = (stop - start) |> ceil
-                    Seq.init (int num + 1) (fun i -> float i + start)
-                else 
-                    let dif = stop - start
-                    let num = 
-                        if System.Math.Round dif = dif then 
-                            floor dif
-                        else 
-                            ceil dif
-                    Seq.init (int num) (fun i -> float i + start)
+                let stepsize = (stop - start) / (float num)
+                Seq.init num (fun i -> stepsize * float i + start)
+
 
         /// <summary>
         /// Creates a geometric seq float with values between a given interval
@@ -1247,12 +1234,11 @@ module SeqExtension =
         /// <param name="stop">end value (by default is included)</param>
         /// <param name="Num">sets the number of elements in the seq. Defaults to 50.</param>
         /// <param name="IncludeEndpoint">If false, the seq does not contain the stop value. Defaults to true.</param>
-        static member inline geomspace (start:float, stop:float, ?Num:int, ?IncludeEndpoint:bool) : seq<float> = 
+        static member inline geomspace (start:float, stop:float, num:int, ?IncludeEndpoint:bool) : seq<float> = 
             if start <= 0. || stop <= 0. then
                 failwith "Geometric space can only take positive values."
 
             let includeEndpoint = defaultArg IncludeEndpoint true
-            let num = defaultArg Num 50
 
             let logStart = System.Math.Log start
             let logStop = System.Math.Log stop

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -1240,6 +1240,30 @@ module SeqExtension =
                             ceil dif
                     Seq.init (int num) (fun i -> float i + start)
 
+        /// <summary>
+        /// Creates a geometric seq float with values between a given interval
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included)</param>
+        /// <param name="Num">sets the number of elements in the seq. Defaults to 50.</param>
+        /// <param name="IncludeEndpoint">If false, the seq does not contain the stop value. Defaults to true.</param>
+        static member inline geomspace (start:float, stop:float, ?Num:int, ?IncludeEndpoint:bool) : seq<float> = 
+            if start <= 0. || stop <= 0. then
+                failwith "Geometric space can only take positive values."
+
+            let includeEndpoint = defaultArg IncludeEndpoint true
+            let num = defaultArg Num 50
+
+            let logStart = System.Math.Log start
+            let logStop = System.Math.Log stop
+
+            let logStep =
+                match includeEndpoint with
+                | true -> (logStop - logStart) / (float num - 1.)
+                | false -> (logStop - logStart)  / (float num)
+
+            Seq.init num (fun x -> (System.Math.Exp (logStart + float x * logStep)))
+
 
 //    // ########################################################################
 //    /// A module which implements functional matrix operations.

--- a/src/FSharp.Stats/Vector.fs
+++ b/src/FSharp.Stats/Vector.fs
@@ -424,4 +424,18 @@ module VectorExtension =
                 Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Vector.ofSeq
             else 
                 Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Vector.ofSeq
+
+        /// <summary>
+        /// Creates a geometric vector of floats with values between a given interval.
+        /// </summary>
+        /// <param name="start">start value (is included)</param>
+        /// <param name="stop">end value (by default is included)</param>
+        /// <param name="Num">sets the number of elements in the vector. Defaults to 50.</param>
+        /// <param name="IncludeEndpoint">If false, the vector does not contain the stop value. Defaults to true.</param>
+        static member geomspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : vector = 
+            let includeEndpoint = defaultArg IncludeEndpoint true
+            let num = defaultArg Num 50
+
+            Seq.geomspace (start, stop ,num, includeEndpoint)
+            |> Vector.ofSeq
    

--- a/src/FSharp.Stats/Vector.fs
+++ b/src/FSharp.Stats/Vector.fs
@@ -416,14 +416,11 @@ module VectorExtension =
         /// <param name="stop">end value (by default is included )</param>
         /// <param name="Num">sets the number of elements in the vector. If not set, stepsize = 1.</param>
         /// <param name="IncludeEndpoint">If false, the vector does not contain the stop value</param>
-        static member linspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : vector = 
+        static member linspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : vector = 
         
             let includeEndpoint = defaultArg IncludeEndpoint true
-
-            if Num.IsSome then 
-                Seq.linspace(start,stop,Num.Value,includeEndpoint) |> Vector.ofSeq
-            else 
-                Seq.linspace(start,stop,IncludeEndpoint=includeEndpoint) |> Vector.ofSeq
+ 
+            Seq.linspace(start,stop,num,includeEndpoint) |> Vector.ofSeq
 
         /// <summary>
         /// Creates a geometric vector of floats with values between a given interval.
@@ -432,9 +429,8 @@ module VectorExtension =
         /// <param name="stop">end value (by default is included)</param>
         /// <param name="Num">sets the number of elements in the vector. Defaults to 50.</param>
         /// <param name="IncludeEndpoint">If false, the vector does not contain the stop value. Defaults to true.</param>
-        static member geomspace(start:float,stop:float,?Num:int,?IncludeEndpoint:bool) : vector = 
+        static member geomspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : vector = 
             let includeEndpoint = defaultArg IncludeEndpoint true
-            let num = defaultArg Num 50
 
             Seq.geomspace (start, stop ,num, includeEndpoint)
             |> Vector.ofSeq

--- a/tests/FSharp.Stats.Tests/Array.fs
+++ b/tests/FSharp.Stats.Tests/Array.fs
@@ -55,38 +55,19 @@ let dropNanTests =
 [<Tests>]
 let linspaceTests =
     testList "Array" [
-        testCase "linspace_0" <| fun () ->
-            let expected = Array.linspace(-3.5,2.5)
-            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5; 2.5|]
-            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
 
         testCase "linspace_1" <| fun () ->
-            let expected = Array.linspace(-3.5,2.5,IncludeEndpoint=false)
-            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5|]
-            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
-
-        testCase "linspace_2" <| fun () ->
-            let expected = Array.linspace(-3.5,2.1)
-            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5; 2.5|]
-            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
-        
-        testCase "linspace_3" <| fun () ->
-            let expected = Array.linspace(-3.5,2.1,IncludeEndpoint=false)
-            let actual = [|-3.5; -2.5; -1.5; -0.5; 0.5; 1.5|]
-            TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
-        
-        testCase "linspace_4" <| fun () ->
-            let expected = Array.linspace(-3.5,30.1,Num=7)
+            let expected = Array.linspace(start= -3.5,stop= 30.1,num=7)
             let actual = [|-3.5; 2.1; 7.7; 13.3; 18.9; 24.5; 30.1|]
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
         
-        testCase "linspace_5" <| fun () ->
-            let expected = Array.linspace(-3.5,2.9,Num=17)
+        testCase "linspace_2" <| fun () ->
+            let expected = Array.linspace(start= -3.5,stop= 2.9,num=17)
             let actual = [|-3.5; -3.1; -2.7; -2.3; -1.9; -1.5; -1.1; -0.7; -0.3;  0.1;  0.5; 0.9;  1.3;  1.7;  2.1;  2.5;  2.9|]
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
         
-        testCase "linspace_6" <| fun () ->
-            let expected = Array.linspace(-3.5,30.1,Num=6,IncludeEndpoint=false)
+        testCase "linspace_3" <| fun () ->
+            let expected = Array.linspace(start= -3.5,stop= 30.1,num=6,IncludeEndpoint=false)
             let actual = [|-3.5;  2.1;  7.7; 13.3; 18.9; 24.5|]
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
       

--- a/tests/FSharp.Stats.Tests/Main.fs
+++ b/tests/FSharp.Stats.Tests/Main.fs
@@ -44,6 +44,8 @@ let main argv =
     Tests.runTestsWithCLIArgs [] argv SeqTests.medianTests |> ignore
     Tests.runTestsWithCLIArgs [] argv SeqTests.meanTests   |> ignore
     Tests.runTestsWithCLIArgs [] argv SeqTests.meanQuadraticTests   |> ignore
+    Tests.runTestsWithCLIArgs [] argv SeqTests.geomspaceTests   |> ignore
+
 
     //============================= Distributions ===========================================================
     Tests.runTestsWithCLIArgs [] argv DistributionsTests.distanceFunctionsTests |> ignore

--- a/tests/FSharp.Stats.Tests/Seq.fs
+++ b/tests/FSharp.Stats.Tests/Seq.fs
@@ -74,27 +74,27 @@ let meanQuadraticTests =
 let geomspaceTests =
     testList "Seq" [
         testCase "geomspace_0" <| fun () ->
-            let expected = Seq.geomspace(10, 1000, 3)
+            let expected = Seq.geomspace(start= 10, stop= 1000, num= 3)
             let actual = seq {10.0; 100.0; 1000.0}
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
 
         testCase "geomspace_1" <| fun () ->
-            let expected = Seq.geomspace(10, 1000, 2, IncludeEndpoint = false)
+            let expected = Seq.geomspace(start= 10, stop= 1000, num= 2, IncludeEndpoint = false)
             let actual = seq {10.0; 100.0}
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
 
         testCase "geomspace_2" <| fun () ->
-            let expected = Seq.geomspace(8, 2, 3)
+            let expected = Seq.geomspace(start= 8, stop= 2, num= 3)
             let actual = seq {8.0; 4.0; 2.0}
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
 
         testCase "geomspace_3" <| fun () ->
-            let expected = Seq.geomspace(0.1, 10, 3)
+            let expected = Seq.geomspace(start= 0.1, stop= 10, num= 3)
             let actual = seq {0.1; 1.0; 10.0}
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
 
         testCase "geomspace_4" <| fun () ->
-            let expected = Seq.geomspace(2., 2. ** 50.)
+            let expected = Seq.geomspace(start= 2., stop= 2. ** 50., num= 50)
             let actual =
                 seq {2.; 4.; 8.; 16.; 32.; 64.; 128.; 256.; 512.; 1024.;
                 2048.; 4096.; 8192.; 16384.; 32768.; 65536.; 131072.;
@@ -109,15 +109,15 @@ let geomspaceTests =
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
 
         testCase "geomspace_5" <| fun () ->
-            let expected() = Seq.geomspace(-2., 2., 3) |> ignore
+            let expected() = Seq.geomspace(start= -2., stop= 2., num= 3) |> ignore
             Expect.throws expected "geomspace cannot be initialized with negative values."
 
         testCase "geomspace_6" <| fun () ->
-            let expected() = Seq.geomspace(2., -2.) |> ignore
+            let expected() = Seq.geomspace(start= 2., stop= -2., num= 3) |> ignore
             Expect.throws expected "geomspace cannot be initialized with negative values."
 
         testCase "geomspace_7" <| fun () ->
-            let expected() = Seq.geomspace(-2., -20.) |> ignore
+            let expected() = Seq.geomspace(start= -2., stop= -20., num= 3) |> ignore
             Expect.throws expected "geomspace cannot be initialized with negative values."
     ]
 

--- a/tests/FSharp.Stats.Tests/Seq.fs
+++ b/tests/FSharp.Stats.Tests/Seq.fs
@@ -107,5 +107,17 @@ let geomspaceTests =
                 70368744177664.; 140737488355328.; 281474976710656.;
                 562949953421312.; 1125899906842624.}
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
+
+        testCase "geomspace_5" <| fun () ->
+            let expected() = Seq.geomspace(-2., 2., 3) |> ignore
+            Expect.throws expected "geomspace cannot be initialized with negative values."
+
+        testCase "geomspace_6" <| fun () ->
+            let expected() = Seq.geomspace(2., -2.) |> ignore
+            Expect.throws expected "geomspace cannot be initialized with negative values."
+
+        testCase "geomspace_7" <| fun () ->
+            let expected() = Seq.geomspace(-2., -20.) |> ignore
+            Expect.throws expected "geomspace cannot be initialized with negative values."
     ]
 

--- a/tests/FSharp.Stats.Tests/Seq.fs
+++ b/tests/FSharp.Stats.Tests/Seq.fs
@@ -3,6 +3,7 @@
 open Expecto
 open System
 open FSharp.Stats
+open TestExtensions
 
 let testSeqEvenCounts = seq [10000.;-0.1;14.;-10.]
 let testSeqOddCounts = seq [10000.;-0.1;14.;-10.;5.]
@@ -68,4 +69,43 @@ let meanQuadraticTests =
             Expect.isTrue (Double.IsNaN mean) "Mean should be nan"
     ]
 
+
+[<Tests>]
+let geomspaceTests =
+    testList "Seq" [
+        testCase "geomspace_0" <| fun () ->
+            let expected = Seq.geomspace(10, 1000, 3)
+            let actual = seq {10.0; 100.0; 1000.0}
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
+
+        testCase "geomspace_1" <| fun () ->
+            let expected = Seq.geomspace(10, 1000, 2, IncludeEndpoint = false)
+            let actual = seq {10.0; 100.0}
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
+
+        testCase "geomspace_2" <| fun () ->
+            let expected = Seq.geomspace(8, 2, 3)
+            let actual = seq {8.0; 4.0; 2.0}
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
+
+        testCase "geomspace_3" <| fun () ->
+            let expected = Seq.geomspace(0.1, 10, 3)
+            let actual = seq {0.1; 1.0; 10.0}
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
+
+        testCase "geomspace_4" <| fun () ->
+            let expected = Seq.geomspace(2., 2. ** 50.)
+            let actual =
+                seq {2.; 4.; 8.; 16.; 32.; 64.; 128.; 256.; 512.; 1024.;
+                2048.; 4096.; 8192.; 16384.; 32768.; 65536.; 131072.;
+                262144.; 524288.; 1048576.; 2097152.; 4194304.; 8388608.;
+                16777216.; 33554432.; 67108864.; 134217728.; 268435456.;
+                536870912.; 1073741824.; 2147483648.; 4294967296.; 8589934592.;
+                17179869184.; 34359738368.; 68719476736.; 137438953472.;
+                274877906944.; 549755813888.; 1099511627776.; 2199023255552.;
+                4398046511104.; 8796093022208.; 17592186044416.; 35184372088832.;
+                70368744177664.; 140737488355328.; 281474976710656.;
+                562949953421312.; 1125899906842624.}
+            TestExtensions.sequenceEqual (Accuracy.high) actual expected "geomspace results in wrong seq"
+    ]
 


### PR DESCRIPTION
Closes #252

**Please list the changes introduced in this PR**

add generic Seq.geomspace
add Vector.geomspace
add Array.geomspace
add List.geomspace
add tests

**Description**

Similar functionality to [np.geomspace](https://numpy.org/doc/stable/reference/generated/numpy.geomspace.html).
*Notes*:
1. I restricted the function to positive values. Numpy allows start and stop to be negative but I found this hacky for the following reasons:
1.1 Exponentiating negative values is a [contentious matter](https://math.stackexchange.com/questions/317528/how-do-you-compute-negative-numbers-to-fractional-powers). E.g. `-2. ** (2./3.) = nan` in F#.
1.2 What numpy does is it computes the geomspace by first changing the sign of start and stop and [then changes it back to negative](https://github.com/numpy/numpy/blob/8cec82012694571156e8d7696307c848a7603b4e/numpy/core/function_base.py#L443). I think this is misleading. If this behavior is what the user wants, I think they should change the sign explicitly, after using the function with positive values.
1.3 Numpy's version throws an unhandled exception when exactly one of start or stop is negative.
2. I'd like add tests for failing cases as it's intended behavior. Can that be done with Expecto, @bvenn?
2.1 Relatedly, I also thought about using Result type returning an Error instead of throwing an exception; but I saw that the general convention was to throw an exception in other parts of the library so I sticked with that.

**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
