### PR TITLE
Lognormal Inv cdf

### DIFF
--- a/src/FSharp.Stats/Distributions/Continuous/LogNormal.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/LogNormal.fs
@@ -70,7 +70,7 @@ type LogNormal =
     /// Computes the inverse cumulative distribution function (quantile function).
     static member InvCDF mu sigma x =
         LogNormal.CheckParam mu sigma            
-        failwithf "InvCDF not implemented yet"
+        Math.Exp (Normal.InvCDF mu sigma x)
  
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support mu sigma =

--- a/tests/FSharp.Stats.Tests/Distributions.fs
+++ b/tests/FSharp.Stats.Tests/Distributions.fs
@@ -1212,6 +1212,33 @@ let normalTests =
                       
     ] 
 
+[<Tests>]
+let logNormalTests =
+
+    testList "Distributions.Continuous.LogNormal" [
+        testCase "InvCDF" <| fun () ->
+            //tested against qlnorm from R
+            let expected_1 = 0.5094162838632775
+            let actual___1 = Distributions.Continuous.LogNormal.InvCDF 0. 1. 0.25
+            let expected_2 = 0.04549138524765352
+            let actual___2 = Distributions.Continuous.LogNormal.InvCDF 0. 1. 0.001
+            let expected_3 = 9.493291347224372e-05
+            let actual___3 = Distributions.Continuous.LogNormal.InvCDF 0. 1. 1e-20
+            let expected_4 = infinity
+            let actual___4 = Distributions.Continuous.LogNormal.InvCDF 300. 100. 1
+            let expected_5 = 0.
+            let actual___5 = Distributions.Continuous.LogNormal.InvCDF 300. 100. 0
+            let expected_6 = 10686474581524.46
+            let actual___6 = Distributions.Continuous.LogNormal.InvCDF 30. 5000. 0.5
+            
+            Expect.floatClose Accuracy.high actual___1 expected_1 "InvCDF1 gives wrong result" 
+            Expect.floatClose Accuracy.high actual___2 expected_2 "InvCDF2 gives wrong result" 
+            Expect.floatClose Accuracy.high actual___3 expected_3 "InvCDF3 gives wrong result" 
+            Expect.equal actual___4 expected_4 "InvCDF4 gives wrong result" 
+            Expect.equal actual___5 expected_5 "InvCDF5 gives wrong result" 
+            Expect.floatClose Accuracy.high actual___6 expected_6 "InvCDF6 gives wrong result"         
+    ] 
+
 
 
 

--- a/tests/FSharp.Stats.Tests/Main.fs
+++ b/tests/FSharp.Stats.Tests/Main.fs
@@ -58,7 +58,7 @@ let main argv =
     Tests.runTestsWithCLIArgs [] argv DistributionsTests.exponentialTests       |> ignore
     Tests.runTestsWithCLIArgs [] argv DistributionsTests.bernoulliTests |> ignore
     Tests.runTestsWithCLIArgs [] argv DistributionsTests.binomialTests          |> ignore 
-    //Tests.runTestsWithCLIArgs [] argv DistributionsTests.logNormal |> ignore
+    Tests.runTestsWithCLIArgs [] argv DistributionsTests.logNormalTests |> ignore
     Tests.runTestsWithCLIArgs [] argv DistributionsEmpiricalTests.empiricalTests |> ignore
 
 


### PR DESCRIPTION
Thank you for contributing to FSharp.Stats. Please take the time to tell us a bit more about your PR.

**Please reference the issue(s) this PR is related to**

#262 (an addition to it, doesn't close)

**Please list the changes introduced in this PR**

- Inv CDF function for the lognormal

**Description**

Uses the exponent of the normal inverse CDF functions which mimics the implementation both in [scipy.stats](https://github.com/scipy/scipy/blob/c1ed5ece8ffbf05356a22a8106affcd11bd3aee0/scipy/stats/_continuous_distns.py#L5637) and [R](https://github.com/SurajGupta/r-source/blob/a28e609e72ed7c47f6ddfbb86c85279a0750f0b7/src/nmath/qlnorm.c#LL29C1-L29C1).

Tested against qlnorm from R.


**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
