### PR TITLE
Making the ID field of SAM entities generic.

### DIFF
--- a/docs/Testing.fsx
+++ b/docs/Testing.fsx
@@ -967,9 +967,16 @@ Therefore, high throughput experiments can be analysed using a combined permutat
 
 (** 
 Data: 
-To use SAM, expression or intensity data need to be in the format (string*float[])[]), with string being the name and float array being the replicates. One way of achieving this is the following data preparation:
+
+To use SAM, expression or intensity data need to be in the format `('id * float[])[]`, where `'id` is a generic type implementing `System.IComparable`.
+
+In this example, `'id` is the name of the gene, and float array being the replicates. 
+
+One way of achieving this is the following data preparation:
+
 <center><img style="max-width:40%" src="https://csbiology.github.io/CSBlog/img/7_SAM/DataPrep.png"/></center>
 *)
+
 (**
 Columns are samples, here 1 and 2, representing control and treatment groups. Rows are transcript counts (here indicated with gene identifier).
 The next step is to read in the data, e.g. via deedle, and to create a dataframe. The rows are indexed by the sample name and the rowkeys are extracted.
@@ -1025,7 +1032,7 @@ Besides the data itself SAM requires the definition of some parameters:
   - _random seed_: The seed is used for randomization of the permutations (System.Random()), or can be fixed to achieve the same results multiple times (e.g. System.Random(1234)).
 
 
-The `SAMResult` type summarizes all information required to construct the typical SAM plot: 
+The `SAMResult<_>` type summarizes all information required to construct the typical SAM plot: 
 
   - _s0_: fudge factor as described by Tusher et al. (2001)
   - _pi0_: {pi0 ∈ R ∣ 0 < x < 1} estimated for the determination of qvalues 


### PR DESCRIPTION
Things went overall smooth, beside the test that checks it doesn't affect the results whatsoever, which requires a bit of infrastructure.

It doesn't seem to affect the end users, unless the code has type annotations referring to `SAM.SAM` or `SAM.SAMResult`.

If this is a concern, we can add an entry to the release note to help end users adjust (suffixing said annotations with `<_>` should do it).

In the implementation, there is a fold which was using `""` as initial state for ID field, since the particular field of the state is basically ignored in the folder, I've put `Unchecked.defaultof` instead in the initial state.