### PR TITLE
rename fitting procedures

### DIFF
--- a/docs/CrossValidation.fsx
+++ b/docs/CrossValidation.fsx
@@ -70,9 +70,9 @@ let yV = vector [1.;20.;51.;40.;37.;6.;-10.;-5.;0.;10.]
 
 // the fitting function fits a polynomial of order 'order' to the training data set (xTrain and yTrain) and applies it to xTest
 let getFitFuncPolynomial xTrain yTrain (xTest:RowVector<float>) order = 
-    let xDat = xTrain |> Matrix.toVector
-    let coeffs  = Polynomial.fit order xDat yTrain
-    let predictFunction     = Polynomial.predict order coeffs (xTest.[0])
+    let xDat             = xTrain |> Matrix.toVector
+    let coeffs           = Polynomial.fit order xDat yTrain
+    let predictFunction  = Polynomial.predict  coeffs (xTest.[0])
     predictFunction
 
 open Plotly.NET
@@ -85,7 +85,7 @@ let chartOrderOpt =
     [1 .. 2 .. 10]
     |> List.map (fun order -> 
         let coeffs = Polynomial.fit order xV yV
-        let predictFunction = Polynomial.predict order coeffs
+        let predictFunction = Polynomial.predict coeffs
         [1. .. 0.2 .. 10.]
         |> List.map (fun x -> x,predictFunction x)
         |> Chart.Line

--- a/docs/CrossValidation.fsx
+++ b/docs/CrossValidation.fsx
@@ -71,9 +71,9 @@ let yV = vector [1.;20.;51.;40.;37.;6.;-10.;-5.;0.;10.]
 // the fitting function fits a polynomial of order 'order' to the training data set (xTrain and yTrain) and applies it to xTest
 let getFitFuncPolynomial xTrain yTrain (xTest:RowVector<float>) order = 
     let xDat = xTrain |> Matrix.toVector
-    let coeffs  = Polynomial.coefficient order xDat yTrain
-    let fit     = Polynomial.fit order coeffs (xTest.[0])
-    fit
+    let coeffs  = Polynomial.fit order xDat yTrain
+    let predictFunction     = Polynomial.predict order coeffs (xTest.[0])
+    predictFunction
 
 open Plotly.NET
 
@@ -84,10 +84,10 @@ let rawchart() =
 let chartOrderOpt = 
     [1 .. 2 .. 10]
     |> List.map (fun order -> 
-        let coeffs = Polynomial.coefficient order xV yV
-        let fit = Polynomial.fit order coeffs
+        let coeffs = Polynomial.fit order xV yV
+        let predictFunction = Polynomial.predict order coeffs
         [1. .. 0.2 .. 10.]
-        |> List.map (fun x -> x,fit x)
+        |> List.map (fun x -> x,predictFunction x)
         |> Chart.Line
         |> Chart.withTraceInfo (sprintf "order=%i" order)
         )

--- a/docs/Fitting.fsx
+++ b/docs/Fitting.fsx
@@ -71,21 +71,21 @@ let yData = vector [|4.;7.;9.;12.;15.;17.;16.;23.;5.;30.|]
 
 //Least squares simple linear regression
 let coefficientsLinearLS = 
-    OrdinaryLeastSquares.Linear.Univariable.coefficient xData yData
-let fittingFunctionLinearLS x = 
-    OrdinaryLeastSquares.Linear.Univariable.fit coefficientsLinearLS x
+    OrdinaryLeastSquares.Linear.Univariable.fit xData yData
+let predictionFunctionLinearLS x = 
+    OrdinaryLeastSquares.Linear.Univariable.predict coefficientsLinearLS x
 
 //Robust simple linear regression
 let coefficientsLinearRobust = 
     RobustRegression.Linear.theilSenEstimator xData yData 
-let fittingFunctionLinearRobust x = 
-    RobustRegression.Linear.fit coefficientsLinearRobust x
+let predictionFunctionLinearRobust x = 
+    RobustRegression.Linear.predict coefficientsLinearRobust x
 
 //least squares simple linear regression through the origin
 let coefficientsLinearRTO = 
-    OrdinaryLeastSquares.Linear.RTO.coefficientOfVector xData yData 
-let fittingFunctionLinearRTO x = 
-    OrdinaryLeastSquares.Linear.RTO.fit coefficientsLinearRTO x
+    OrdinaryLeastSquares.Linear.RTO.fitOfVector xData yData 
+let predictionFunctionLinearRTO x = 
+    OrdinaryLeastSquares.Linear.RTO.predict coefficientsLinearRTO x
 
 
 
@@ -93,29 +93,29 @@ let rawChart =
     Chart.Point(xData,yData)
     |> Chart.withTraceInfo "raw data"
     
-let fittingLS = 
+let predictionLS = 
     let fit = 
         [|0. .. 11.|] 
-        |> Array.map (fun x -> x,fittingFunctionLinearLS x)
+        |> Array.map (fun x -> x,predictionFunctionLinearLS x)
     Chart.Line(fit)
     |> Chart.withTraceInfo "least squares (LS)"
 
-let fittingRobust = 
+let predictionRobust = 
     let fit = 
         [|0. .. 11.|] 
-        |> Array.map (fun x -> x,fittingFunctionLinearRobust x)
+        |> Array.map (fun x -> x,predictionFunctionLinearRobust x)
     Chart.Line(fit)
     |> Chart.withTraceInfo "TheilSen estimator"
 
-let fittingRTO = 
+let predictionRTO = 
     let fit = 
         [|0. .. 11.|] 
-        |> Array.map (fun x -> x,fittingFunctionLinearRTO x)
+        |> Array.map (fun x -> x,predictionFunctionLinearRTO x)
     Chart.Line(fit)
     |> Chart.withTraceInfo "LS through origin"
 
 let simpleLinearChart =
-    [rawChart;fittingLS;fittingRTO;fittingRobust;] 
+    [rawChart;predictionLS;predictionRTO;predictionRobust;] 
     |> Chart.combine
     |> Chart.withTemplate ChartTemplates.lightMirrored
 
@@ -153,9 +153,9 @@ let yVectorMulti =
     |> vector
 
 let coefficientsMV = 
-    OrdinaryLeastSquares.Linear.Multivariable.coefficients xVectorMulti yVectorMulti
-let fittingFunctionMV x = 
-    OrdinaryLeastSquares.Linear.Multivariable.fit coefficientsMV x
+    OrdinaryLeastSquares.Linear.Multivariable.fit xVectorMulti yVectorMulti
+let predictionFunctionMV x = 
+    OrdinaryLeastSquares.Linear.Multivariable.predict coefficientsMV x
 
 (**
 
@@ -176,9 +176,9 @@ let yDataP = vector [|4.;7.;9.;8.;6.;3.;2.;5.;6.;8.;|]
 //define the order the polynomial should have (order 3: f(x) = ax^3 + bx^2 + cx + d)
 let order = 3
 let coefficientsPol = 
-    OrdinaryLeastSquares.Polynomial.coefficient order xDataP yDataP 
-let fittingFunctionPol x = 
-    OrdinaryLeastSquares.Polynomial.fit order coefficientsPol x
+    OrdinaryLeastSquares.Polynomial.fit order xDataP yDataP 
+let predictionFunctionPol x = 
+    OrdinaryLeastSquares.Polynomial.predict order coefficientsPol x
 
 //weighted least squares polynomial regression
 //If heteroscedasticity is assumed or the impact of single datapoints should be 
@@ -190,9 +190,9 @@ let orderP = 3
 //define the weighting vector
 let weights = yDataP |> Vector.map (fun y -> 1. / y)
 let coefficientsPolW = 
-    OrdinaryLeastSquares.Polynomial.coefficientsWithWeighting orderP weights xDataP yDataP 
-let fittingFunctionPolW x = 
-    OrdinaryLeastSquares.Polynomial.fit orderP coefficientsPolW x
+    OrdinaryLeastSquares.Polynomial.fitWithWeighting orderP weights xDataP yDataP 
+let predictionFunctionPolW x = 
+    OrdinaryLeastSquares.Polynomial.predict orderP coefficientsPolW x
 
 let rawChartP = 
     Chart.Point(xDataP,yDataP)
@@ -201,14 +201,14 @@ let rawChartP =
 let fittingPol = 
     let fit = 
         [|1. .. 0.1 .. 10.|] 
-        |> Array.map (fun x -> x,fittingFunctionPol x)
+        |> Array.map (fun x -> x,predictionFunctionPol x)
     Chart.Line(fit)
     |> Chart.withTraceInfo "order = 3"
 
 let fittingPolW = 
     let fit = 
         [|1. .. 0.1 .. 10.|] 
-        |> Array.map (fun x -> x,fittingFunctionPolW x)
+        |> Array.map (fun x -> x,predictionFunctionPolW x)
     Chart.Line(fit)
     |> Chart.withTraceInfo "order = 3 weigthed"
 
@@ -314,7 +314,7 @@ let initialParamGuess (xData:float []) (yData:float [])=
     //(prone to least-squares-deviations at high y_Values)
     let yLn = yData |> Array.map (fun x -> Math.Log(x)) |> vector
     let linearReg = 
-        LinearRegression.OrdinaryLeastSquares.Linear.Univariable.coefficient (vector xData) yLn
+        LinearRegression.OrdinaryLeastSquares.Linear.Univariable.fit (vector xData) yLn
     //calculates the parameters back into the exponential representation
     let a = exp linearReg.[0]
     let b = linearReg.[1]

--- a/docs/GoodnessOfFit.fsx
+++ b/docs/GoodnessOfFit.fsx
@@ -59,10 +59,10 @@ let x = vector [|1. .. 10.|]
 let y = vector [|4.;10.;9.;7.;13.;17.;16.;23.;15.;30.|]
 
 ///linear regression line fitting function
-let coefficients = Linear.Univariable.coefficient x y
-let fitFunc = Linear.Univariable.fit coefficients
+let coefficients = Linear.Univariable.fit x y
+let predictFunc = Linear.Univariable.predict coefficients
 
-let fittedValues = x |> Seq.map fitFunc
+let fittedValues = x |> Seq.map predictFunc
 
 
 let chart =
@@ -87,7 +87,7 @@ Various quality parameters can be accessed via the `GoodnessOfFit` module:
 *)
 
 //In the following some quality/interval/significance values are computed:
-let sos         = GoodnessOfFit.calculateSumOfSquares fitFunc x y
+let sos         = GoodnessOfFit.calculateSumOfSquares predictFunc x y
 let n           = sos.Count
 let meanX       = sos.MeanX
 let meanY       = sos.MeanY
@@ -189,10 +189,10 @@ let yData = vector [|4.;10.;9.;7.;13.;17.;16.;23.;15.;30.|]
 let values = Seq.zip xData yData
 
 ///linear regression line fitting function
-let coeffs = Linear.Univariable.coefficient xData yData
-let fit = Linear.Univariable.fit coeffs
+let coeffs = Linear.Univariable.fit xData yData
+let predictionFunction = Linear.Univariable.predict coeffs
 
-let fitValues = xData |> Seq.map (fun xi -> xi,(fit xi))
+let fitValues = xData |> Seq.map (fun xi -> xi,(predictionFunction xi))
 
 ///calculate confidence band errors for every x value
 let confidence = 
@@ -203,7 +203,7 @@ let confidence =
 let (lower,upper) = 
     xData 
     |> Vector.toArray
-    |> Array.mapi (fun i xi -> (fit xi) - confidence.[i],(fit xi) + confidence.[i]) 
+    |> Array.mapi (fun i xi -> (predictionFunction xi) - confidence.[i],(predictionFunction xi) + confidence.[i]) 
     |> Array.unzip
 
 let rangePlot = 
@@ -248,7 +248,7 @@ let newConfidence =
 let (newLower,newUpper) = 
     newXValues 
     |> Vector.toArray
-    |> Array.mapi (fun i xi -> (fit xi) - newConfidence.[i],(fit xi) + newConfidence.[i]) 
+    |> Array.mapi (fun i xi -> (predictionFunction xi) - newConfidence.[i],(predictionFunction xi) + newConfidence.[i]) 
     |> Array.unzip
 
 let linePlot =
@@ -287,7 +287,7 @@ let prediction =
 let (pLower,pUpper) = 
     predictionXValues 
     |> Vector.toArray
-    |> Array.mapi (fun i xi -> (fit xi) - prediction.[i],(fit xi) + prediction.[i]) 
+    |> Array.mapi (fun i xi -> (predictionFunction xi) - prediction.[i],(predictionFunction xi) + prediction.[i]) 
     |> Array.unzip
 
 let predictionPlot =

--- a/docs/GrowthCurve.fsx
+++ b/docs/GrowthCurve.fsx
@@ -151,7 +151,7 @@ let generationTime = log(2.) / slope
 
 
 let fittedValues = 
-    let f = OrdinaryLeastSquares.Linear.Univariable.predict (vector [|14.03859475; 1.515073487|])
+    let f = OrdinaryLeastSquares.Linear.Univariable.predict (Coefficients (vector [14.03859475; 1.515073487]))
     logPhaseX |> Seq.map (fun x -> x,f x)
 
 let chartLinearRegression =

--- a/docs/GrowthCurve.fsx
+++ b/docs/GrowthCurve.fsx
@@ -140,7 +140,7 @@ let logPhaseY = vector cellCountLn.[3..11]
 
 // regression coefficients as [intercept;slope]
 let regressionCoeffs =
-    OrdinaryLeastSquares.Linear.Univariable.coefficient logPhaseX logPhaseY
+    OrdinaryLeastSquares.Linear.Univariable.fit logPhaseX logPhaseY
 
 (**Here is a pre-evaluated version (to save time during the build process, as the solver takes quite some time.)*)
 
@@ -151,7 +151,7 @@ let generationTime = log(2.) / slope
 
 
 let fittedValues = 
-    let f = OrdinaryLeastSquares.Linear.Univariable.fit (vector [|14.03859475; 1.515073487|])
+    let f = OrdinaryLeastSquares.Linear.Univariable.predict (vector [|14.03859475; 1.515073487|])
     logPhaseX |> Seq.map (fun x -> x,f x)
 
 let chartLinearRegression =

--- a/docs/Interpolation.fsx
+++ b/docs/Interpolation.fsx
@@ -48,7 +48,7 @@ _Summary:_ This tutorial demonstrates several ways of interpolating with FSharp.
 ## Summary
 
 With the `FSharp.Stats.Interpolation` module you can apply various interpolation methods. While interpolating functions always go through the input points (knots), methods to predict function values 
-from x values (or x vectors in multivariate interpolation) not contained in the input, vary greatly. A `Interpolation` type provides all available methods for interpolation of two dimensional data. These include
+from x values (or x vectors in multivariate interpolation) not contained in the input, vary greatly. A `Interpolation` type provides many common methods for interpolation of two dimensional data. These include
 
 - Linear spline interpolation (connecting knots by straight lines)
 - Polynomial interpolation
@@ -92,7 +92,7 @@ let interpolationComparison =
     |> Chart.combine
     |> Chart.withTemplate ChartTemplates.lightMirrored
     |> Chart.withXAxisStyle("x data")
-    |> Chart.withYAxisStyle("x data")
+    |> Chart.withYAxisStyle("y data")
     |> Chart.withSize(800.,600.)
 
 

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -119,11 +119,11 @@ let yData = vector [|4.;7.;9.;12.;15.;17.;16.;23.;5.;30.|]
 
 // get coefficients of interpolating polynomial
 let interpolatingCoefficients = 
-    Interpolation.Polynomial.coefficients xData yData
+    Interpolation.Polynomial.interpolate xData yData
 
 // get fitting function of interpolating polynomial
 let interpolFitFunc = 
-    Interpolation.Polynomial.fit interpolatingCoefficients
+    Interpolation.Polynomial.predict interpolatingCoefficients
 
 (*** hide ***)
 // create line chart of interpolating polynomial
@@ -138,17 +138,17 @@ let interpolChart =
 
 // get coefficients of 3rd order regression polynomial
 let regressionCoefficients = 
-    Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.coefficient 3 xData yData
+    Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.fit 3 xData yData
     
 // get fitting function of 3rd order regression polynomial
-let regressionFitFunc = 
-    Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.fit 3 regressionCoefficients
+let regressionPredictionFunc = 
+    Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.predict 3 regressionCoefficients
 
 (*** hide ***)
 // create line chart of regression polynomial
 let regressionChart = 
     [1. .. 0.1 .. 10.] 
-    |> List.map (fun x -> x,regressionFitFunc x)
+    |> List.map (fun x -> x,regressionPredictionFunc x)
     |> fun data -> Chart.Line(data,Name="regression polynomial")
 
 let combinedChart =

--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -142,7 +142,7 @@ let regressionCoefficients =
     
 // get fitting function of 3rd order regression polynomial
 let regressionPredictionFunc = 
-    Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.predict 3 regressionCoefficients
+    Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.predict regressionCoefficients
 
 (*** hide ***)
 // create line chart of regression polynomial

--- a/src/FSharp.Stats/Algebra/LinearAlgebra.fs
+++ b/src/FSharp.Stats/Algebra/LinearAlgebra.fs
@@ -112,8 +112,8 @@ module LinearAlgebra =
         LinearAlgebraManaged.Inverse a
 
     /// Given A[m,n] and B[m] solves AX = B for X[n].
-    /// When m=>n, have over constrained system, finds least squares solution for X.
-    /// When m<n, have under constrained system, finds least norm solution for X.
+    /// When m =&gt; n, have over constrained system, finds least squares solution for X.
+    /// When m &lt; n, have under constrained system, finds least norm solution for X.
     let LeastSquares a b =
         //if HaveService() then LinearAlgebraService.leastSquares a b
         //                    else LinearAlgebraManaged.leastSquares a b
@@ -143,8 +143,8 @@ module LinearAlgebra =
       
 
     /// Given A[m,n] finds Q[m,m] and R[k,n] where k = min m n.
-    /// Have A = Q.R  when m<=n.
-    /// Have A = Q.RX when m>n and RX[m,n] is R[n,n] row extended with (m-n) zero rows.
+    /// Have A = Q.R  when m &lt; =n.
+    /// Have A = Q.RX when m &gt; n and RX[m,n] is R[n,n] row extended with (m-n) zero rows.
     let QR a = 
         //if HaveService() then LinearAlgebraService.QR a
         //                    else LinearAlgebraManaged.QR a

--- a/src/FSharp.Stats/Distributions/Continuous/Beta.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Beta.fs
@@ -69,7 +69,7 @@ type Beta =
         else log 0.0
         
     /// <summary> Computes the probability density function.</summary> 
-    /// <remarks> Calls exp(PDFLn) if alpha,beta > 80</remarks> 
+    /// <remarks> Calls exp(PDFLn) if alpha,beta &gt; 80</remarks> 
     static member PDF alpha beta x = 
         Beta.CheckParam alpha beta
         if x >= 0.0 && x <= 1.0 then

--- a/src/FSharp.Stats/Distributions/Discrete/Bernoulli.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Bernoulli.fs
@@ -57,7 +57,7 @@ type Bernoulli =
         | 1 -> p
         | _ -> 0.0
 
-    /// Computes the cumulative distribution function. P(X>=k)
+    /// Computes the cumulative distribution function. P(X &gt;= k)
     static member CDF p x =
         Bernoulli.CheckParam p
         // Summary: This cdf calculates the probability, that value x is greater or equal to a random value (R) taken from the bernoulli distribution.

--- a/src/FSharp.Stats/Distributions/Discrete/Binomial.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Binomial.fs
@@ -84,7 +84,7 @@ type Binomial =
             exp ( (SpecialFunctions.Binomial._coeffcientLn n k) + (float k * log p + ( float (n - k)*log(1.-p) )) )
 
             
-    /// Computes the cumulative distribution function at x, i.e. P(X <= x).
+    /// Computes the cumulative distribution function at x, i.e. P(X &lt;= x).
     static member CDF p n (x:float) =
         Binomial.CheckParam p n            
         if (x < 0.) then 

--- a/src/FSharp.Stats/Distributions/Discrete/Hypergeometric.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Hypergeometric.fs
@@ -98,7 +98,7 @@ type Hypergeometric =
         else
             exp ((SpecialFunctions.Binomial._coeffcientLn K k) + (SpecialFunctions.Binomial._coeffcientLn (N-K) (n-k)) - SpecialFunctions.Binomial._coeffcientLn N n)
         
-    /// Computes the cumulative distribution function at x, i.e. P(X <= x).
+    /// Computes the cumulative distribution function at x, i.e. P(X &lt;= x).
     static member CDF N K n x =
         Hypergeometric.CheckParam N K n
         //Hypergeometric.CheckParam_k N K n k
@@ -180,7 +180,7 @@ type Hypergeometric =
             member d.Mode               = Hypergeometric.Mode N K n
             member d.Sample ()          = Hypergeometric.Sample N K n
             member d.PMF k              = Hypergeometric.PMF N K n k
-            /// Computes the cumulative distribution function at k for P(X <= k).
+            /// Computes the cumulative distribution function at k for P(X &lt;= k).
             member d.Parameters        = DistributionParameters.Hypergeometric {N=N;K=K;n=n}
             override d.ToString()       = Hypergeometric.ToString N K n                   
         }

--- a/src/FSharp.Stats/Distributions/Discrete/Poisson.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Poisson.fs
@@ -111,7 +111,7 @@ type Poisson =
         else
             (lambda**float k * System.Math.E**(-lambda)) / SpecialFunctions.Factorial.factorial k
         
-    /// Computes the cumulative distribution function at x, i.e. P(X <= x).
+    /// Computes the cumulative distribution function at x, i.e. P(X &lt;= x).
     static member CDF lambda k =
         Poisson.CheckParam lambda        
         Gamma.upperIncompleteRegularized (k + 1.) lambda

--- a/src/FSharp.Stats/Fitting/CrossValidation.fs
+++ b/src/FSharp.Stats/Fitting/CrossValidation.fs
@@ -72,7 +72,7 @@ module CrossValidation =
     /// yData: yData vector
     /// fit: x and y data lead to function that maps a xData row vector to a y-coordinate,
     /// error: defines the error of the fitted y-coordinate and the actual y-coordinate,
-    /// getStDev: function that calculates the standard deviation from a seq<^T>. (Seq.stDev)
+    /// getStDev: function that calculates the standard deviation from a seq&lt;^T&gt;. (Seq.stDev)
     let inline repeatedKFold< ^T when ^T : (static member ( + ) : ^T * ^T -> ^T) 
                     and  ^T : (static member DivideByInt : ^T*int -> ^T) 
                     and  ^T : (static member Zero : ^T)> 
@@ -158,7 +158,7 @@ module CrossValidation =
     /// yData: yData vector
     /// fit: x and y data lead to function that maps a xData row vector to a y-coordinate,
     /// error: defines the error of the fitted y-coordinate and the actual y-coordinate,
-    /// getStDev: function that calculates the standard deviation from a seq<^T>. (Seq.stDev)
+    /// getStDev: function that calculates the standard deviation from a seq&lt;^T&gt;. (Seq.stDev)
     let inline shuffelAndSplit< ^T when ^T : (static member ( + ) : ^T * ^T -> ^T) 
                     and  ^T : (static member DivideByInt : ^T*int -> ^T) 
                     and  ^T : (static member Zero : ^T)>

--- a/src/FSharp.Stats/Fitting/GoodnessOfFit.fs
+++ b/src/FSharp.Stats/Fitting/GoodnessOfFit.fs
@@ -210,7 +210,7 @@ module GoodnessOfFit =
             open LinearRegression.OrdinaryLeastSquares.Linear
             module RTO = 
                 /// 
-                let calculateANOVA (coef : float) x y =                
+                let calculateANOVA (coef : LinearRegression.Coefficients) x y =                
                     calculateANOVA 1 (LinearRegression.OrdinaryLeastSquares.Linear.RTO.predictFunc coef) x y 
 
             module Univariable = 
@@ -298,7 +298,7 @@ module GoodnessOfFit =
                                         |> vector
                                     let coefTmp = LinearRegression.OrdinaryLeastSquares.Polynomial.fit order xTmp yTmp
                                     let error = 
-                                        let yFit = LinearRegression.OrdinaryLeastSquares.Polynomial.predict order coefTmp (float xData.[x])
+                                        let yFit = LinearRegression.OrdinaryLeastSquares.Polynomial.predict coefTmp (float xData.[x])
                                         pown (yFit - yData.[x]) 2 
                                     error
                                 )
@@ -349,7 +349,7 @@ module GoodnessOfFit =
                             let dataLeftOut = x
                             let fit = 
                                 Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.fit order (vector subX) (vector subY)
-                                |> fun coeffs -> Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.predict order coeffs
+                                |> fun coeffs -> Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.predict coeffs
                             dataLeftOut
                             |> Array.map (fun (xLO,yLO) -> pown (fit xLO - yLO) 2)
                             |> Array.sum

--- a/src/FSharp.Stats/Fitting/GoodnessOfFit.fs
+++ b/src/FSharp.Stats/Fitting/GoodnessOfFit.fs
@@ -211,7 +211,7 @@ module GoodnessOfFit =
             module RTO = 
                 /// 
                 let calculateANOVA (coef : float) x y =                
-                    calculateANOVA 1 (LinearRegression.OrdinaryLeastSquares.Linear.RTO.fitFunc coef) x y 
+                    calculateANOVA 1 (LinearRegression.OrdinaryLeastSquares.Linear.RTO.predictFunc coef) x y 
 
             module Univariable = 
 
@@ -227,8 +227,8 @@ module GoodnessOfFit =
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
                     let n = float xData.Length
                     let df = n - 2.
-                    let coefficients = Univariable.coefficient xData yData
-                    let fitFunction = Univariable.fit coefficients 
+                    let coefficients = Univariable.fit xData yData
+                    let fitFunction = Univariable.predict coefficients 
                     let meanX = Seq.mean xData
                     let SseOfX = 
                         xData 
@@ -250,8 +250,8 @@ module GoodnessOfFit =
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
                     let n = float xData.Length
                     let df = n - 2.
-                    let coefficients = Univariable.coefficient xData yData
-                    let fitFunction = Univariable.fit coefficients 
+                    let coefficients = Univariable.fit xData yData
+                    let fitFunction = Univariable.predict coefficients 
                     let meanX = Seq.mean xData
                     let SseOfX = 
                         xData 
@@ -296,9 +296,9 @@ module GoodnessOfFit =
                                         |> Seq.toList
                                         |> fun yDat -> yDat.[..x-1]@yDat.[x+1..]
                                         |> vector
-                                    let coefTmp = LinearRegression.OrdinaryLeastSquares.Polynomial.coefficient order xTmp yTmp
+                                    let coefTmp = LinearRegression.OrdinaryLeastSquares.Polynomial.fit order xTmp yTmp
                                     let error = 
-                                        let yFit = LinearRegression.OrdinaryLeastSquares.Polynomial.fit order coefTmp (float xData.[x])
+                                        let yFit = LinearRegression.OrdinaryLeastSquares.Polynomial.predict order coefTmp (float xData.[x])
                                         pown (yFit - yData.[x]) 2 
                                     error
                                 )
@@ -348,8 +348,8 @@ module GoodnessOfFit =
                                 |> Array.unzip
                             let dataLeftOut = x
                             let fit = 
-                                Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.coefficient order (vector subX) (vector subY)
-                                |> fun coeffs -> Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.fit order coeffs
+                                Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.fit order (vector subX) (vector subY)
+                                |> fun coeffs -> Fitting.LinearRegression.OrdinaryLeastSquares.Polynomial.predict order coeffs
                             dataLeftOut
                             |> Array.map (fun (xLO,yLO) -> pown (fit xLO - yLO) 2)
                             |> Array.sum

--- a/src/FSharp.Stats/Fitting/LinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/LinearRegression.fs
@@ -1,13 +1,13 @@
 namespace FSharp.Stats.Fitting
 
 
+open System
+open FSharp.Stats
+
 /// <summary>
 ///   Linear regression is used to estimate the relationship of one variable (y) with another (x) by expressing y in terms of a linear function of x.
 /// </summary>
 module LinearRegression =    
-
-    open FSharp.Stats
-    
 //    ///Least Squares Linear Regressio
 //    module General =
 //        // define our target functions
@@ -30,9 +30,9 @@ module LinearRegression =
 //        // solve
 //        let p = X.QR().Solve(y)
 //        let (a,b) = (p.[0], p.[1])
-
+        
     /// <summary>
-    ///   OLS regression aims to minimise the sum of squared y intercepts between the original and predicted points at each x value.
+    ///   Ordinary Least Squares (OLS) regression aims to minimise the sum of squared y intercepts between the original and predicted points at each x value.
     /// </summary>
     module OrdinaryLeastSquares = 
           
@@ -61,15 +61,21 @@ module LinearRegression =
                 /// 
                 /// // Estimate the slope of the regression line.
                 /// let coefficients = 
-                ///     LinearRegression.OrdinaryLeastSquares.Linear.coefficient xData yData 
+                ///     LinearRegression.OrdinaryLeastSquares.Linear.fit xData yData 
                 /// </code> 
                 /// </example>
-                let coefficientOfVector (xData : Vector<float>) (yData : Vector<float>) =
+                let fitOfVector (xData : Vector<float>) (yData : Vector<float>) =
                     if xData.Length <> yData.Length then
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
                     let numerator   = Seq.zip xData yData |> Seq.sumBy (fun (x,y) -> x * y)
                     let denominator = xData |> Seq.sumBy (fun x -> x * x)
-                    numerator / denominator
+                    let slope = numerator / denominator
+                    slope
+                    //Coefficient.Create (vector [0.;slope])
+
+                [<Obsolete("Use RTO.fitOfVector instead.")>]
+                let coefficientOfVector (xData : Vector<float>) (yData : Vector<float>) = 
+                    fitOfVector xData yData
 
                 /// <summary>
                 ///   Calculates the slope of a regression line through the origin  
@@ -86,11 +92,15 @@ module LinearRegression =
                 /// 
                 /// // Estimate the slope of the regression line.
                 /// let coefficients = 
-                ///     LinearRegression.OrdinaryLeastSquares.Linear.RTO.coefficient xData yData 
+                ///     LinearRegression.OrdinaryLeastSquares.Linear.RTO.fit xData yData 
                 /// </code> 
                 /// </example>
-                let coefficient (xData : seq<float>) (yData : seq<float>) =
-                    coefficientOfVector (vector xData) (vector yData)
+                let fit (xData : seq<float>) (yData : seq<float>) =
+                    fitOfVector (vector xData) (vector yData)
+
+                [<Obsolete("Use RTO.fit instead.")>]
+                let coefficient (xData : Vector<float>) (yData : Vector<float>) = 
+                    fitOfVector xData yData
                 
                 /// <summary>
                 ///   Returns the regression function of a line through the origin
@@ -103,15 +113,14 @@ module LinearRegression =
                 ///
                 /// // get the fítting function that fits through the origin
                 /// let myF = 
-                ///     LinearRegression.OrdinaryLeastSquares.Linear.RTO.fitFunc mySlope
+                ///     LinearRegression.OrdinaryLeastSquares.Linear.RTO.predictFunc mySlope
                 ///
                 /// // Returns predicted y value at x=6 using a line with intercept=0 and slope=17.8
                 /// myF 6.
                 /// </code> 
                 /// </example>
-                let fitFunc (coef: float) =            
+                let predictFunc (coef: float) =
                     fun x -> coef * x
-                
 
                 /// <summary>
                 ///   Predicts the y value for a given slope and x value (intercept=0)
@@ -124,10 +133,10 @@ module LinearRegression =
                 /// let mySlope = 17.8
                 ///
                 /// // Returns predicted y value at x=6 using a line with intercept=0 and slope=17.8
-                /// LinearRegression.OrdinaryLeastSquares.Linear.RTO.fit mySlope 6.
+                /// LinearRegression.OrdinaryLeastSquares.Linear.RTO.predict mySlope 6.
                 /// </code> 
                 /// </example>
-                let fit (coef: float) (x:float) =            
+                let predict (coef: float) (x:float) =            
                     coef * x
 
             /// <summary>
@@ -150,15 +159,19 @@ module LinearRegression =
                 /// 
                 /// // Estimate the coefficients of a straight line fitting the given data
                 /// let coefficients = 
-                ///     Univariable.coefficient xData yData 
+                ///     Univariable.fit xData yData 
                 /// </code> 
                 /// </example>
-                let coefficient (xData : Vector<float>) (yData : Vector<float>) =
+                let fit (xData : Vector<float>) (yData : Vector<float>) =
                     if xData.Length <> yData.Length then
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
                     let N = xData.Length
                     let X = Matrix.init N 2 (fun m x ->  if x = 0 then 1. else xData.[m] )
                     Algebra.LinearAlgebra.LeastSquares X yData
+                    
+                [<Obsolete("Use Univariable.fit instead.")>]
+                let coefficient (xData : Vector<float>) (yData : Vector<float>) = 
+                    fit xData yData
 
                 /// <summary>
                 ///   Calculates the intercept and slope for a straight line fitting the data using Cholesky Decomposition. Linear regression minimizes the sum of squared residuals.
@@ -175,10 +188,10 @@ module LinearRegression =
                 /// 
                 /// // Estimate the coefficients of a straight line fitting the given data
                 /// let coefficients = 
-                ///     Univariable.coefficientCholesky xData yData 
+                ///     Univariable.fitCholesky xData yData 
                 /// </code> 
                 /// </example>
-                let coefficientCholesky (xData: Vector<float>) (yData: Vector<float>) =
+                let fitCholesky (xData: Vector<float>) (yData: Vector<float>) =
                     if xData.NumRows <> yData.Length then
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
 
@@ -186,6 +199,11 @@ module LinearRegression =
                         Matrix.init (xData.Length) 2 (fun i j -> if j = 0 then 1.0 else xData.[i])
 
                     Algebra.LinearAlgebra.LeastSquaresCholesky X yData
+
+                
+                [<Obsolete("Use Univariable.fitCholesky instead.")>]
+                let coefficientCholesky (xData : Vector<float>) (yData : Vector<float>) = 
+                    fitCholesky xData yData
 
                 /// <summary>
                 ///   Calculates the intercept and slope for a straight line fitting the data and passing through a specified point (xC,yC) . Linear regression minimizes the sum of squared residuals.
@@ -202,15 +220,20 @@ module LinearRegression =
                 /// 
                 /// // Estimate the coefficients of a straight line fitting the given data
                 /// let coefficients = 
-                ///     Univariable.coefficientConstrained xData yData (6.,15.)
+                ///     Univariable.fitConstrained xData yData (6.,15.)
                 /// </code> 
                 /// </example>
-                let coefficientConstrained (xData : Vector<float>) (yData : Vector<float>) ((xC,yC): float*float) =
+                let fitConstrained (xData : Vector<float>) (yData : Vector<float>) ((xC,yC): float*float) =
                     let xTransformed = xData |> Vector.map (fun x -> x - xC)
                     let yTransformed = yData |> Vector.map (fun y -> y - yC)
-                    let slope = RTO.coefficientOfVector xTransformed yTransformed
+                    let slope = RTO.fitOfVector xTransformed yTransformed
                     [|- xC * slope - yC;slope|]
+
                 
+                [<Obsolete("Use Univariable.fitConstrained instead.")>]
+                let coefficientConstrained (xData : Vector<float>) (yData : Vector<float>) = 
+                    fitConstrained xData yData
+
                 /// <summary>
                 ///   Takes intercept and slope of simple linear regression to predict the corresponding y value.
                 /// </summary>
@@ -226,13 +249,13 @@ module LinearRegression =
                 /// 
                 /// // Estimate the coefficients of a straight line fitting the given data
                 /// let coefficients = 
-                ///     Univariable.coefficient xData yData 
+                ///     Univariable.fit xData yData 
                 ///
                 /// // Predict the feature at midnight between day 1 and 2. 
-                /// Univariable.fit coefficients 1.5
+                /// Univariable.predict coefficients 1.5
                 /// </code> 
                 /// </example>
-                let fit (coef : Vector<float>) (x:float) =
+                let predict (coef : Vector<float>) (x:float) =
                     if coef.Length <> 2 then
                         raise (System.ArgumentException("Coefficient has to be [a;b]!"))
                     coef.[0] + coef.[1] * x
@@ -262,7 +285,7 @@ module LinearRegression =
                     let X = Matrix.init N 2 (fun m x ->  if x = 0 then 1. else xData.[m] )
                     let coeffs = Algebra.LinearAlgebra.LeastSquares X yData
                     let leverages = Algebra.LinearAlgebra.leverage X
-                    let yPred = Vector.map (fit coeffs) xData
+                    let yPred = Vector.map (predict coeffs) xData
                     let squaredDeviations = Vector.map2 (fun y yPr -> (y - yPr) ** 2.)  yPred yData 
                     let MSE = squaredDeviations |> Vector.sum |> fun sumOfSquares -> sumOfSquares / (float xData.Length)         
                     // compute cooksDistance for every Point in the dataSet
@@ -307,17 +330,22 @@ module LinearRegression =
                 ///       |> vector
                 ///   
                 ///   let coefficientsMV = 
-                ///       Multivariable.coefficients xVectorMulti yVectorMulti
+                ///       Multivariable.fit xVectorMulti yVectorMulti
                 /// </code> 
                 /// </example>
-                let coefficients (xData : Matrix<float>) (yData : Vector<float>) =
+                let fit (xData : Matrix<float>) (yData : Vector<float>) =
                     if xData.NumRows <> yData.Length then
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
                     let m = xData.NumRows
                     let n = xData.NumCols
                     let X = Matrix.init m (n+1) (fun m n ->  if n = 0 then 1. else xData.[m,n-1] )
                     Algebra.LinearAlgebra.LeastSquares X yData
+                    
+                [<Obsolete("Use Multivariable.fit instead.")>]
+                let coefficients (xData : Matrix<float>) (yData : Vector<float>) = 
+                    fit xData yData
 
+                /// <summary>
                 /// <summary>
                 ///   Calculates the coefficients for a straight line fitting the data using Cholesky Decomposition. Linear regression minimizes the sum of squared residuals.
                 /// </summary>
@@ -347,10 +375,10 @@ module LinearRegression =
                 ///       |> vector
                 ///   
                 ///   let coefficientsMV = 
-                ///       Multivariable.coefficientsCholesky xVectorMulti yVectorMulti
+                ///       Multivariable.fitCholesky xVectorMulti yVectorMulti
                 /// </code> 
                 /// </example>
-                let coefficientsCholesky (xData: Matrix<float>) (yData: Vector<float>) =
+                let fitCholesky (xData: Matrix<float>) (yData: Vector<float>) =
                     if xData.NumRows <> yData.Length then
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
 
@@ -359,7 +387,11 @@ module LinearRegression =
                             (fun i j -> if j = 0 then 1.0 else xData.[i, j - 1])
 
                     Algebra.LinearAlgebra.LeastSquaresCholesky X yData
-                
+                    
+                [<Obsolete("Use Multivariable.fitCholesky instead.")>]
+                let coefficientsCholesky (xData : Matrix<float>) (yData : Vector<float>) = 
+                    fitCholesky xData yData
+
                 /// <summary>
                 ///   Takes linear coefficients and x vector to predict the corresponding y value.
                 /// </summary>
@@ -389,35 +421,40 @@ module LinearRegression =
                 ///       |> vector
                 ///   
                 ///   let coefficientsMV = 
-                ///       Multivariable.coefficients xVectorMulti yVectorMulti
+                ///       Multivariable.fit xVectorMulti yVectorMulti
                 ///
                 ///   let fittingFunctionMV x = 
-                ///       Multivariable.fit coefficientsMV x
+                ///       Multivariable.predict coefficientsMV x
                 /// </code> 
                 /// </example>
-                let fit (coef: Vector<float>) (x: Vector<float>) =
+                let predict (coef: Vector<float>) (x: Vector<float>) =
                     let tmp: Vector<float> = Vector.init (x.Length+1) (fun i -> if i = 0 then 1. else x.[i-1])
                     Vector.dot tmp coef 
             
             module RidgeRegression =           
                 
-                let coefficients lambda (xData : Matrix<float>) (yData : Vector<float>) =
+
+                let fit lambda (xData : Matrix<float>) (yData : Vector<float>) =
                     if xData.NumRows <> yData.Length then
                         raise (System.ArgumentException("vector x and y have to be the same size!"))
                     let m = xData.NumRows
                     let n = xData.NumCols
                     let X = Matrix.init m (n+1) (fun m n ->  if n = 0 then 1. else xData.[m,n-1] )
                     
-                    let lambdaIdentity = lambda * Matrix.identity n
+                    let lambdaIdentity = lambda .* Matrix.identity n
                     let sumDot = X.Transpose * X + lambdaIdentity
                     let theInverse = Algebra.LinearAlgebra.Inverse sumDot
                     let inverseXt = theInverse * X.Transpose
                     let w = inverseXt * yData
  
                     w
+                    
+                [<Obsolete("Use RidgeRegression.fit instead.")>]
+                let coefficients lambda (xData : Matrix<float>) (yData : Vector<float>) = 
+                    fit lambda xData yData
 
                 /// Fit to x
-                let fit (coef : Vector<float>) (x:Vector<float>) =
+                let predict (coef : Vector<float>) (x:Vector<float>) =
                     let tmp :Vector<float> = Vector.init (x.Length+1) (fun i -> if i = 0 then 1. else x.[i-1])
                     Vector.dot tmp coef 
 
@@ -451,10 +488,10 @@ module LinearRegression =
             /// 
             /// // Estimate the three coefficients of a quadratic polynomial.
             /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.coefficients 2 xData yData 
+            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit 2 xData yData 
             /// </code> 
             /// </example>
-            let coefficient order (xData : Vector<float>) (yData : Vector<float>) =
+            let fit order (xData : Vector<float>) (yData : Vector<float>) =
                 if xData.Length <> yData.Length then
                     raise (System.ArgumentException("vector x and y have to be the same size!"))
                 let N = xData.Length
@@ -465,6 +502,10 @@ module LinearRegression =
                 let AtA = A.Transpose * A
                 let Aty = A.Transpose * yData
                 Algebra.LinearAlgebra.LeastSquares AtA Aty        
+
+            [<Obsolete("Use Polynomial.fit instead.")>]
+            let coefficient order (xData : Vector<float>) (yData : Vector<float>) = 
+                fit order xData yData
 
             /// <summary>
             ///   Calculates the polynomial coefficients for polynomial regression with a given point weighting. 
@@ -483,10 +524,10 @@ module LinearRegression =
             /// 
             /// // Estimate the three coefficients of a quadratic polynomial.
             /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.coefficients 2 xData yData 
+            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit 2 xData yData 
             /// </code> 
             /// </example>
-            let coefficientsWithWeighting order (weighting : Vector<float>) (xData : Vector<float>) (yData : Vector<float>) = 
+            let fitWithWeighting order (weighting : Vector<float>) (xData : Vector<float>) (yData : Vector<float>) = 
                 if xData.Length <> yData.Length || xData.Length <> weighting.Length then
                     raise (System.ArgumentException("vector x,y and weighting have to be the same size!"))
                 let A = 
@@ -505,6 +546,10 @@ module LinearRegression =
                             |> Vector.sum
                         )
                 Algebra.LinearAlgebra.SolveLinearSystem A b   
+                
+            [<Obsolete("Use Polynomial.fitWithWeighting instead.")>]
+            let coefficientsWithWeighting order (weighting : Vector<float>) (xData : Vector<float>) (yData : Vector<float>) = 
+                fitWithWeighting order weighting xData yData
 
             /////takes vector of data with n>1 replicates and gives a vector of weightings based on the variance in measurements ( 1/var(i..j) )
             /////only apply if y > 0 !
@@ -533,14 +578,14 @@ module LinearRegression =
             /// 
             /// // Define the polynomial coefficients.
             /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.coefficients xData yData 
+            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit xData yData 
             /// 
             /// // Predict the temperature value at midnight between day 1 and 2. 
-            /// LinearRegression.OrdinaryLeastSquares.Polynomial.fit coefficients 1.5
+            /// LinearRegression.OrdinaryLeastSquares.Polynomial.predict coefficients 1.5
             /// </code> 
             /// </example>
             /// <remarks>If all coefficients are nonzero, the order is equal to the length of the coefficient vector!</remarks>
-            let fit (order) (coef : Vector<float>) (x:float) =            
+            let predict (order) (coef : Vector<float>) (x:float) =            
                 Vector.dot coef (vandermondeRow order x)
 
             /// <summary>
@@ -559,7 +604,7 @@ module LinearRegression =
             /// 
             /// // Estimate the polynomial coefficients
             /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.coefficients xData yData 
+            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit xData yData 
             /// 
             /// // Predict the curvature of the regression function at midnight between day 1 and 2. 
             /// LinearRegression.OrdinaryLeastSquares.Polynomial.getDerivative coefficients 2 1.5
@@ -605,7 +650,7 @@ module LinearRegression =
                 let A = vandermondeMatrix order xData
                 let coeffs = Algebra.LinearAlgebra.LeastSquares A yData
                 let leverages = Algebra.LinearAlgebra.leverage A
-                let yPred = Vector.map (fit order coeffs) xData
+                let yPred = Vector.map (predict order coeffs) xData
                 let squaredDeviations = Vector.map2 (fun y yPr -> (y - yPr) ** 2.)  yPred yData 
                 let MSE = squaredDeviations |> Vector.sum |> fun sumOfSquares -> sumOfSquares / (float xData.Length)         
                 // compute cooksDistance for every Point in the dataSet
@@ -615,11 +660,8 @@ module LinearRegression =
                     let sndFactor = leverages.[i] / ((1. - leverages.[i]) ** 2.)
                     fstFactor * sndFactor
                 )
-                                   
-            // <summary>
-            // Find the model parameters ? such that X*? with predictor X becomes as close to response Y as possible, with least squares residuals.
-            // Uses a singular value decomposition and is therefore more numerically stable (especially if ill-conditioned) than the normal equations or QR but also slower.
-            // </summary>            
+
+
 
     /// <summary>
     ///   Robust regression does not necessarily minimize the distance of the fitting function to the input data points (least squares), but has alternative aims (non-parametric).
@@ -746,8 +788,13 @@ module LinearRegression =
             ///     LinearRegression.RobustRegression.Linear.theilEstimator xData yData
             ///
             /// // Predict the size on day 10.5
-            /// LinearRegression.RobustRegression.Linear.fit coefficients 10.5 
+            /// LinearRegression.RobustRegression.Linear.predict coefficients 10.5 
             /// </code> 
             /// </example>
-            /// <remarks>Equal to OrdinaryLeastSquares.Linear.Univariable.fit!</remarks>
-            let fit coef x = OrdinaryLeastSquares.Linear.Univariable.fit coef x
+            /// <remarks>Equal to OrdinaryLeastSquares.Linear.Univariable.predict!</remarks>
+            let predict coef x = OrdinaryLeastSquares.Linear.Univariable.predict coef x
+
+
+            [<Obsolete("Use Linear.predict instead.")>]
+            let fit coef x = 
+                predict coef x

--- a/src/FSharp.Stats/Fitting/LinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/LinearRegression.fs
@@ -8,41 +8,30 @@ open FSharp.Stats
 ///   Linear regression is used to estimate the relationship of one variable (y) with another (x) by expressing y in terms of a linear function of x.
 /// </summary>
 module LinearRegression =    
-//    ///Least Squares Linear Regressio
-//    module General =
-//        // define our target functions
-//        let f1 x = Math.Sqrt(Math.Exp(x))
-//        let f2 x = SpecialFunctions.DiGamma(x*x)
-//
-//        // create data samples, with chosen parameters and with gaussian noise added
-//        let fy (noise:IContinuousDistribution) x = 2.5*f1(x) - 4.0*f2(x) + noise.Sample()
-//        let xdata = [ 1.0 .. 1.0 .. 10.0 ]
-//        let ydata = xdata |> List.map (fy (Normal.WithMeanVariance(0.0,2.0)))
-//
-//        // build matrix form
-//        let X =
-//            [|
-//                xdata |> List.map f1 |> vector
-//                xdata |> List.map f2 |> vector
-//            |] |> DenseMatrix.CreateFromColumns
-//        let y = vector ydata
-//
-//        // solve
-//        let p = X.QR().Solve(y)
-//        let (a,b) = (p.[0], p.[1])
         
     type Coefficients(coefficients: vector) =
         let n = coefficients.Length
-        member this.Coefficients =  coefficients
-        member this.Count =         n
-        member this.Degree =        n - 1
-        member this.Constant =      if n = 0 then 0. else coefficients.[0]
-        member this.Linear =        if n < 2 then 0. else coefficients.[1]
-        member this.Quadratic =     if n < 3 then 0. else coefficients.[2]
-        member this.Cubic =         if n < 4 then 0. else coefficients.[3]
-        member this.Leading =       if n = 0 then 0. else Seq.last coefficients
-        member this.getCoefficient degree = coefficients.[degree]
-        member this.Item degree = coefficients.[degree] 
+        member this.Coefficients            = coefficients
+        member this.Count                   = n
+        member this.Degree                  = n - 1
+        member this.Constant                = if n = 0 then 0. else coefficients.[0]
+        member this.Linear                  = if n < 2 then 0. else coefficients.[1]
+        member this.Quadratic               = if n < 3 then 0. else coefficients.[2]
+        member this.Cubic                   = if n < 4 then 0. else coefficients.[3]
+        member this.Leading                 = if n = 0 then 0. else Seq.last coefficients
+        member this.getCoefficient degree   = coefficients.[degree]
+        member this.Item degree             = coefficients.[degree] 
+        override this.ToString()            = 
+            let body = 
+                coefficients 
+                |> Seq.mapi (fun degree coefficient -> 
+                    if degree = 0 then sprintf "%.3f" coefficient
+                    elif degree = 1 then sprintf "%.3fx" coefficient
+                    else sprintf "%.3fx^%i" coefficient degree
+                    ) 
+                |> String.concat " + " 
+            "f(x) = " + body
+
         static member Init(coefficients) = Coefficients(coefficients)
         static member Empty() = Coefficients(vector [])
 
@@ -69,14 +58,14 @@ module LinearRegression =
                 /// <returns>Slope of the regression line through the origin</returns>
                 /// <example> 
                 /// <code> 
-                /// // e.g. days since a certain event
-                /// let xData = vector [|0.;1.;2.;3.;4.;5.;|]
-                /// // some measured feature, that theoretically is zero at day 0
-                /// let yData = vector [|1.;5.;9.;13.;17.;18.;|]
-                /// 
-                /// // Estimate the slope of the regression line.
-                /// let coefficients = 
-                ///     LinearRegression.OrdinaryLeastSquares.Linear.fit xData yData 
+                ///   // e.g. days since a certain event
+                ///   let xData = vector [|0.;1.;2.;3.;4.;5.;|]
+                ///   // some measured feature, that theoretically is zero at day 0
+                ///   let yData = vector [|1.;5.;9.;13.;17.;18.;|]
+                ///   
+                ///   // Estimate the slope of the regression line.
+                ///   let coefficients = 
+                ///       LinearRegression.OrdinaryLeastSquares.Linear.fit xData yData 
                 /// </code> 
                 /// </example>
                 let fitOfVector (xData : Vector<float>) (yData : Vector<float>) =
@@ -99,15 +88,15 @@ module LinearRegression =
                 /// <returns>Slope of the regression line through the origin</returns>
                 /// <example> 
                 /// <code> 
-                /// // e.g. days since a certain event
-                /// let xData = vector [|0.;1.;2.;3.;4.;5.;|]
-                /// // some measured feature, that theoretically is zero at day 0
-                /// let yData = vector [|1.;5.;9.;13.;17.;18.;|]
-                /// 
-                /// // Estimate the slope of the regression line.
-                /// let coefficients = 
-                ///     LinearRegression.OrdinaryLeastSquares.Linear.RTO.fit xData yData 
-                /// </code> 
+                ///   // e.g. days since a certain event
+                ///   let xData = vector [|0.;1.;2.;3.;4.;5.;|]
+                ///   // some measured feature, that theoretically is zero at day 0
+                ///   let yData = vector [|1.;5.;9.;13.;17.;18.;|]
+                ///   
+                ///   // Estimate the slope of the regression line.
+                ///   let coefficients = 
+                ///       LinearRegression.OrdinaryLeastSquares.Linear.RTO.fit xData yData 
+                ///   </code> 
                 /// </example>
                 let fit (xData : seq<float>) (yData : seq<float>) =
                     fitOfVector (vector xData) (vector yData)
@@ -123,14 +112,14 @@ module LinearRegression =
                 /// <returns>Function that takes a x value and returns the predicted y value</returns>
                 /// <example> 
                 /// <code> 
-                /// let mySlope = 17.8
-                ///
-                /// // get the fítting function that fits through the origin
-                /// let myF = 
-                ///     LinearRegression.OrdinaryLeastSquares.Linear.RTO.predictFunc mySlope
-                ///
-                /// // Returns predicted y value at x=6 using a line with intercept=0 and slope=17.8
-                /// myF 6.
+                ///   let mySlope = 17.8
+                ///   
+                ///   // get the fítting function that fits through the origin
+                ///   let myF = 
+                ///       LinearRegression.OrdinaryLeastSquares.Linear.RTO.predictFunc mySlope
+                ///   
+                ///   // Returns predicted y value at x=6 using a line with intercept=0 and slope=17.8
+                ///   myF 6.
                 /// </code> 
                 /// </example>
                 let predictFunc (coef: Coefficients) =
@@ -144,10 +133,10 @@ module LinearRegression =
                 /// <returns>predicted y value</returns>
                 /// <example> 
                 /// <code> 
-                /// let mySlope = 17.8
-                ///
-                /// // Returns predicted y value at x=6 using a line with intercept=0 and slope=17.8
-                /// LinearRegression.OrdinaryLeastSquares.Linear.RTO.predict mySlope 6.
+                ///   let mySlope = 17.8
+                ///   
+                ///   // Returns predicted y value at x=6 using a line with intercept=0 and slope=17.8
+                ///   LinearRegression.OrdinaryLeastSquares.Linear.RTO.predict mySlope 6.
                 /// </code> 
                 /// </example>
                 let predict (coef: Coefficients) (x: float) =            
@@ -166,14 +155,14 @@ module LinearRegression =
                 /// <returns>vector of [intercept; slope]</returns>
                 /// <example> 
                 /// <code> 
-                /// // e.g. days since a certain event
-                /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-                /// // e.g. some measured feature 
-                /// let yData = vector [|4.;7.;9.;10.;11.;15.|]
-                /// 
-                /// // Estimate the coefficients of a straight line fitting the given data
-                /// let coefficients = 
-                ///     Univariable.fit xData yData 
+                ///   // e.g. days since a certain event
+                ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+                ///   // e.g. some measured feature 
+                ///   let yData = vector [|4.;7.;9.;10.;11.;15.|]
+                ///   
+                ///   // Estimate the coefficients of a straight line fitting the given data
+                ///   let coefficients = 
+                ///       Univariable.fit xData yData 
                 /// </code> 
                 /// </example>
                 let fit (xData: Vector<float>) (yData: Vector<float>) =
@@ -196,14 +185,14 @@ module LinearRegression =
                 /// <returns>vector of [intercept; slope]</returns>
                 /// <example> 
                 /// <code> 
-                /// // e.g. days since a certain event
-                /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-                /// // e.g. some measured feature 
-                /// let yData = vector [|4.;7.;9.;10.;11.;15.|]
-                /// 
-                /// // Estimate the coefficients of a straight line fitting the given data
-                /// let coefficients = 
-                ///     Univariable.fitCholesky xData yData 
+                ///   // e.g. days since a certain event
+                ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+                ///   // e.g. some measured feature 
+                ///   let yData = vector [|4.;7.;9.;10.;11.;15.|]
+                ///   
+                ///   // Estimate the coefficients of a straight line fitting the given data
+                ///   let coefficients = 
+                ///       Univariable.fitCholesky xData yData 
                 /// </code> 
                 /// </example>
                 let fitCholesky (xData: Vector<float>) (yData: Vector<float>) =
@@ -229,14 +218,14 @@ module LinearRegression =
                 /// <returns>vector of [intercept; slope]</returns>
                 /// <example> 
                 /// <code> 
-                /// // e.g. days since a certain event
-                /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-                /// // e.g. some measured feature 
-                /// let yData = vector [|4.;7.;9.;10.;11.;15.|]
-                /// 
-                /// // Estimate the coefficients of a straight line fitting the given data
-                /// let coefficients = 
-                ///     Univariable.fitConstrained xData yData (6.,15.)
+                ///   // e.g. days since a certain event
+                ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+                ///   // e.g. some measured feature 
+                ///   let yData = vector [|4.;7.;9.;10.;11.;15.|]
+                ///   
+                ///   // Estimate the coefficients of a straight line fitting the given data
+                ///   let coefficients = 
+                ///       Univariable.fitConstrained xData yData (6.,15.)
                 /// </code> 
                 /// </example>
                 let fitConstrained (xData : Vector<float>) (yData : Vector<float>) ((xC,yC): float*float) =
@@ -259,17 +248,17 @@ module LinearRegression =
                 /// <returns>predicted y value with given coefficients at X=x</returns>
                 /// <example> 
                 /// <code> 
-                /// // e.g. days since a certain event
-                /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-                /// // e.g. some measured feature 
-                /// let yData = vector [|4.;7.;9.;10.;11.;15.|]
-                /// 
-                /// // Estimate the coefficients of a straight line fitting the given data
-                /// let coefficients = 
-                ///     Univariable.fit xData yData 
-                ///
-                /// // Predict the feature at midnight between day 1 and 2. 
-                /// Univariable.predict coefficients 1.5
+                ///   // e.g. days since a certain event
+                ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+                ///   // e.g. some measured feature 
+                ///   let yData = vector [|4.;7.;9.;10.;11.;15.|]
+                ///   
+                ///   // Estimate the coefficients of a straight line fitting the given data
+                ///   let coefficients = 
+                ///       Univariable.fit xData yData 
+                ///   
+                ///   // Predict the feature at midnight between day 1 and 2. 
+                ///   Univariable.predict coefficients 1.5
                 /// </code> 
                 /// </example>
                 let predict (coef : Coefficients) (x:float) =
@@ -286,13 +275,13 @@ module LinearRegression =
                 /// <returns>Collection of cooks distances for every input coordinate.</returns>
                 /// <example> 
                 /// <code> 
-                /// // e.g. days since a certain event
-                /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-                /// // e.g. some measured feature 
-                /// let yData = vector [|4.;7.;9.;10.;11.;15.|]
-                /// 
-                /// let distances = 
-                ///     Univariable.cooksDistance xData yData 
+                ///   // e.g. days since a certain event
+                ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+                ///   // e.g. some measured feature 
+                ///   let yData = vector [|4.;7.;9.;10.;11.;15.|]
+                ///   
+                ///   let distances = 
+                ///       Univariable.cooksDistance xData yData 
                 /// </code> 
                 /// </example>
                 let cooksDistance (xData : Vector<float>) (yData : Vector<float>) =
@@ -339,7 +328,7 @@ module LinearRegression =
                 ///   
                 ///   // Here the x values are transformed. In most cases the y values are just provided.
                 ///   let yVectorMulti = 
-                ///       let transformX (x:Matrix<float>) =
+                ///       let transformX (x) =
                 ///           x
                 ///           |> Matrix.mapiRows (fun _ v -> 100. + (v.[0] * 2.5) + (v.[1] * 4.) + (v.[2] * 0.5))
                 ///       xVectorMulti
@@ -363,7 +352,6 @@ module LinearRegression =
                     (fit xData yData).Coefficients
 
                 /// <summary>
-                /// <summary>
                 ///   Calculates the coefficients for a straight line fitting the data using Cholesky Decomposition. Linear regression minimizes the sum of squared residuals.
                 /// </summary>
                 /// <param name="xData">matrix of x vectors</param>
@@ -384,7 +372,7 @@ module LinearRegression =
                 ///   
                 ///   // Here the x values are transformed. In most cases the y values are just provided.
                 ///   let yVectorMulti = 
-                ///       let transformX (x:Matrix<float>) =
+                ///       let transformX (x) =
                 ///           x
                 ///           |> Matrix.mapiRows (fun _ v -> 100. + (v.[0] * 2.5) + (v.[1] * 4.) + (v.[2] * 0.5))
                 ///       xVectorMulti
@@ -430,7 +418,7 @@ module LinearRegression =
                 ///   
                 ///   // Here the x values are transformed. In most cases the y values are just provided.
                 ///   let yVectorMulti = 
-                ///       let transformX (x:Matrix<float>) =
+                ///       let transformX (x) =
                 ///           x
                 ///           |> Matrix.mapiRows (fun _ v -> 100. + (v.[0] * 2.5) + (v.[1] * 4.) + (v.[2] * 0.5))
                 ///       xVectorMulti
@@ -498,14 +486,14 @@ module LinearRegression =
             /// <returns>vector of polynomial coefficients sorted as [intercept;constant;quadratic;...]</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since a certain event
-            /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-            /// // e.g. temperature measured at noon of the days specified in xData 
-            /// let yData = vector [|4.;7.;9.;8.;7.;9.;|]
-            /// 
-            /// // Estimate the three coefficients of a quadratic polynomial.
-            /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit 2 xData yData 
+            ///   // e.g. days since a certain event
+            ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+            ///   // e.g. temperature measured at noon of the days specified in xData 
+            ///   let yData = vector [|4.;7.;9.;8.;7.;9.;|]
+            ///   
+            ///   // Estimate the three coefficients of a quadratic polynomial.
+            ///   let coefficients = 
+            ///       LinearRegression.OrdinaryLeastSquares.Polynomial.fit 2 xData yData 
             /// </code> 
             /// </example>
             let fit order (xData : Vector<float>) (yData : Vector<float>) =
@@ -534,14 +522,14 @@ module LinearRegression =
             /// <returns>vector of polynomial coefficients sorted as [intercept;constant;quadratic;...]</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since a certain event
-            /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-            /// // e.g. temperature measured at noon of the days specified in xData 
-            /// let yData = vector [|4.;7.;9.;8.;7.;9.;|]
-            /// 
-            /// // Estimate the three coefficients of a quadratic polynomial.
-            /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit 2 xData yData 
+            ///   // e.g. days since a certain event
+            ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+            ///   // e.g. temperature measured at noon of the days specified in xData 
+            ///   let yData = vector [|4.;7.;9.;8.;7.;9.;|]
+            ///   
+            ///   // Estimate the three coefficients of a quadratic polynomial.
+            ///   let coefficients = 
+            ///       LinearRegression.OrdinaryLeastSquares.Polynomial.fit 2 xData yData 
             /// </code> 
             /// </example>
             let fitWithWeighting order (weighting : Vector<float>) (xData : Vector<float>) (yData : Vector<float>) = 
@@ -568,8 +556,8 @@ module LinearRegression =
             let coefficientsWithWeighting order (weighting : Vector<float>) (xData : Vector<float>) (yData : Vector<float>) = 
                 (fitWithWeighting order weighting xData yData).Coefficients
 
-            /////takes vector of data with n>1 replicates and gives a vector of weightings based on the variance in measurements ( 1/var(i..j) )
-            /////only apply if y > 0 !
+            //takes vector of data with n>1 replicates and gives a vector of weightings based on the variance in measurements ( 1/var(i..j) )
+            //only apply if y > 0 !
             //let getWeightingOfVariance numberOfReplicates (yData:Vector<float>) =
             //    let var =
             //        if yData.Length % numberOfReplicates = 0 then
@@ -577,7 +565,7 @@ module LinearRegression =
             //            let variance = vector [for i = 0 to length-1 do yield yData.[i * numberOfReplicates .. (i + 1) * numberOfReplicates - 1] |> Seq.var]
             //            variance
             //        else raise (System.ArgumentException("data length no multiple of replicate number!")) 
-            //    Vector.init (yData.Length / numberOfReplicates) (fun i -> 1. / var.[i])
+            //    Vector.init (yData.Length / numberOfReplicates) (fun i - 1. / var.[i])
                         
             /// <summary>
             ///   Takes polynomial coefficients and x value to predict the corresponding y value.
@@ -588,17 +576,17 @@ module LinearRegression =
             /// <returns>predicted y value with given polynomial coefficients at X=x</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since a certain event
-            /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-            /// // e.g. temperature measured at noon of the days specified in xData 
-            /// let yData = vector [|4.;7.;9.;8.;7.;9.;|]
-            /// 
-            /// // Define the polynomial coefficients.
-            /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit xData yData 
-            /// 
-            /// // Predict the temperature value at midnight between day 1 and 2. 
-            /// LinearRegression.OrdinaryLeastSquares.Polynomial.predict coefficients 1.5
+            ///   // e.g. days since a certain event
+            ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+            ///   // e.g. temperature measured at noon of the days specified in xData 
+            ///   let yData = vector [|4.;7.;9.;8.;7.;9.;|]
+            ///   
+            ///   // Define the polynomial coefficients.
+            ///   let coefficients = 
+            ///       LinearRegression.OrdinaryLeastSquares.Polynomial.fit xData yData 
+            ///   
+            ///   // Predict the temperature value at midnight between day 1 and 2. 
+            ///   LinearRegression.OrdinaryLeastSquares.Polynomial.predict coefficients 1.5
             /// </code> 
             /// </example>
             /// <remarks>If all coefficients are nonzero, the order is equal to the length of the coefficient vector!</remarks>
@@ -614,17 +602,17 @@ module LinearRegression =
             /// <returns>predicted derivative with given polynomial coefficients at X=x</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since a certain event
-            /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-            /// // e.g. temperature measured at noon of the days specified in xData 
-            /// let yData = vector [|4.;7.;9.;8.;7.;9.;|]
-            /// 
-            /// // Estimate the polynomial coefficients
-            /// let coefficients = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.fit xData yData 
-            /// 
-            /// // Predict the curvature of the regression function at midnight between day 1 and 2. 
-            /// LinearRegression.OrdinaryLeastSquares.Polynomial.getDerivative coefficients 2 1.5
+            ///   // e.g. days since a certain event
+            ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+            ///   // e.g. temperature measured at noon of the days specified in xData 
+            ///   let yData = vector [|4.;7.;9.;8.;7.;9.;|]
+            ///   
+            ///   // Estimate the polynomial coefficients
+            ///   let coefficients = 
+            ///       LinearRegression.OrdinaryLeastSquares.Polynomial.fit xData yData 
+            ///   
+            ///   // Predict the curvature of the regression function at midnight between day 1 and 2. 
+            ///   LinearRegression.OrdinaryLeastSquares.Polynomial.getDerivative coefficients 2 1.5
             /// </code> 
             /// </example>
             let getDerivative (*(order: int)*) (coef: Coefficients) (level: int) (x: float) =
@@ -650,14 +638,14 @@ module LinearRegression =
             /// <returns>returns collection of cooks distances for each data point</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since a certain event
-            /// let xData = vector [|1.;2.;3.;4.;5.;6.|]
-            /// // e.g. temperature measured at noon of the days specified in xData 
-            /// let yData = vector [|4.;7.;9.;8.;7.;9.;|]
-            ///
-            /// // Returns distances for a quadratic polynomial
-            /// let distances = 
-            ///     LinearRegression.OrdinaryLeastSquares.Polynomial.cooksDistance 2 xData yData 
+            ///   // e.g. days since a certain event
+            ///   let xData = vector [|1.;2.;3.;4.;5.;6.|]
+            ///   // e.g. temperature measured at noon of the days specified in xData 
+            ///   let yData = vector [|4.;7.;9.;8.;7.;9.;|]
+            ///   
+            ///   // Returns distances for a quadratic polynomial
+            ///   let distances = 
+            ///       LinearRegression.OrdinaryLeastSquares.Polynomial.cooksDistance 2 xData yData 
             /// </code> 
             /// </example>
             let cooksDistance order (xData : Vector<float>) (yData : Vector<float>) =
@@ -696,14 +684,14 @@ module LinearRegression =
             /// <returns>vector of polynomial coefficients sorted as [intercept;constant;quadratic;...]</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since experiment start
-            /// let xData = vector [|1. .. 100.|]
-            /// // e.g. plant size in cm
-            /// let yData = vector [|4.;7.;8.;9.;7.;11.; ...|]
-            /// 
-            /// // Estimate the intercept and slope of a line, that fits the data.
-            /// let coefficients = 
-            ///     LinearRegression.RobustRegression.Linear.theilEstimator xData yData 
+            ///   // e.g. days since experiment start
+            ///   let xData = vector [|1. .. 100.|]
+            ///   // e.g. plant size in cm
+            ///   let yData = vector [|4.;7.;8.;9.;7.;11.; ...|]
+            ///   
+            ///   // Estimate the intercept and slope of a line, that fits the data.
+            ///   let coefficients = 
+            ///       LinearRegression.RobustRegression.Linear.theilEstimator xData yData 
             /// </code> 
             /// </example>
             /// <remarks>Not robust if data count is low! http://195.134.76.37/applets/AppletTheil/Appl_Theil2.html</remarks>
@@ -748,14 +736,14 @@ module LinearRegression =
             /// <returns>vector of polynomial coefficients sorted as [intercept;constant;quadratic;...]</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since experiment start
-            /// let xData = vector [|1. .. 100.|]
-            /// // e.g. plant size in cm
-            /// let yData = vector [|4.;7.;8.;9.;7.;11.; ...|]
-            /// 
-            /// // Estimate the intercept and slope of a line, that fits the data.
-            /// let coefficients = 
-            ///     LinearRegression.RobustRegression.Linear.theilSenEstimator xData yData 
+            ///   // e.g. days since experiment start
+            ///   let xData = vector [|1. .. 100.|]
+            ///   // e.g. plant size in cm
+            ///   let yData = vector [|4.;7.;8.;9.;7.;11.; ...|]
+            ///   
+            ///   // Estimate the intercept and slope of a line, that fits the data.
+            ///   let coefficients = 
+            ///       LinearRegression.RobustRegression.Linear.theilSenEstimator xData yData 
             /// </code> 
             /// </example>
             /// <remarks>Not robust if data count is low!</remarks>
@@ -793,17 +781,17 @@ module LinearRegression =
             /// <returns>predicted y value with given coefficients at X=x</returns>
             /// <example> 
             /// <code> 
-            /// // e.g. days since experiment start
-            /// let xData = vector [|1. .. 100.|]
-            /// // e.g. plant size in cm
-            /// let yData = vector [|4.;7.;8.;9.;7.;11.; ...|]
-            /// 
-            /// // Estimate the intercept and slope of a line, that fits the data.
-            /// let coefficients = 
-            ///     LinearRegression.RobustRegression.Linear.theilEstimator xData yData
-            ///
-            /// // Predict the size on day 10.5
-            /// LinearRegression.RobustRegression.Linear.predict coefficients 10.5 
+            ///   // e.g. days since experiment start
+            ///   let xData = vector [|1. .. 100.|]
+            ///   // e.g. plant size in cm
+            ///   let yData = vector [|4.;7.;8.;9.;7.;11.; ...|]
+            ///   
+            ///   // Estimate the intercept and slope of a line, that fits the data.
+            ///   let coefficients = 
+            ///       LinearRegression.RobustRegression.Linear.theilEstimator xData yData
+            ///   
+            ///   // Predict the size on day 10.5
+            ///   LinearRegression.RobustRegression.Linear.predict coefficients 10.5 
             /// </code> 
             /// </example>
             /// <remarks>Equal to OrdinaryLeastSquares.Linear.Univariable.predict!</remarks>
@@ -829,22 +817,13 @@ type Constraint<'a> =
     | RegressionThroughXY of 'a
     
 /// <summary>
-///   Defines if independent variable is a scalar (univariable) or vector (multivariable).
-/// </summary>
-type FitData =
-    /// <summary>Two dimensional data</summary>
-    | Univariable of vector
-    /// <summary>Multi dimensional data</summary>
-    | Multivariable of matrix
-    
-/// <summary>
 ///   Defines method of slope estimation for robust line regression.
 /// </summary>
 type RobustEstimator = 
     /// <summary>Theils incomplete method</summary>
     | Theil
     /// <summary>Theil Sen estimator</summary>
-    | TheilSenEstimator
+    | TheilSen
     
 /// <summary>
 ///   Defines regression method.
@@ -857,10 +836,58 @@ type Method =
     /// <summary>Fits an outlier-insensitive straight line through twodimensional data (NOT OLS).</summary>
     | Robust of RobustEstimator
 
-
+/// <summary>
+///   This LinearRegression type summarized the most common fitting procedures.
+/// </summary>
+/// <returns>Either linear regression coefficients or a prediction function to map x values/vectors to its corresponding y value.</returns>
+/// <example> 
+/// <code> 
+///   // e.g. days since experiment start
+///   let xData = vector [|1. .. 100.|]
+///   // e.g. plant size in cm
+///   let yData = vector [|4.;7.;8.;9.;7.;11.; ...|]
+///   
+///   // Estimate the intercept and slope of a line, that fits the data.
+///   let coefficientsSimpleLinear = 
+///       LinearRegression.fit(xData,yData,FittingMethod=Fitting.Method.SimpleLinear,Constraint=Fitting.Constraint.RegressionThroughOrigin)
+///   
+///   // Predict the size on day 10.5
+///   LinearRegression.predict(coefficientsSimpleLinear) 10.5
+/// </code> 
+/// </example>
 type LinearRegression() = 
 
-    static member fit(xData: vector, yData, ?FittingMethod: Method, ?Constraint: Constraint<float*float>, ?Weighting: vector option) = 
+    /// <summary>
+    ///   Determines coefficients for univariate linear regression.
+    /// </summary>
+    /// <param name="xData">vector of x values</param>
+    /// <param name="yData">vector of y values</param>
+    /// <param name="FittingMethod">Either Fitting.SimpleLinear (straight line), Fitting.Polynomial (polynomial), or Fitting.Robust (outlier insensitive straight line).</param>
+    /// <param name="Constraint">Either Fitting.Unconstrained, Fitting.RegressionThroughOrigin, or Fitting.RegressionThroughXY (x,y) with x,y beeing coordinates that the line must pass.</param>
+    /// <param name="Weighting">If a pointwise weight should be attached, a weight vector can be given, that is in the same order as x/y values.</param>
+    /// <returns>Linear regression coefficients.</returns>
+    /// <example> 
+    /// <code> 
+    ///   // e.g. days since experiment start
+    ///   let xData = vector [|1.; 2.; 3.; 4.; 5.; 6. |]
+    ///   // e.g. plant size in cm
+    ///   let yData = vector [|4.; 7.; 8.; 9.; 7.; 11.|]
+    ///   
+    ///   // Estimate the intercept and slope of a line, that fits the data.
+    ///   let coefficientsSimpleLinear = 
+    ///       LinearRegression.fit(xData,yData,FittingMethod=Fitting.Method.SimpleLinear,Constraint=Fitting.Constraint.RegressionThroughXY (1.,2.))
+    ///   
+    ///   // Estimate the coefficients of a cubic polynomial that fits the data with the given point weighting.
+    ///   let coefficientsPolynomial = 
+    ///       LinearRegression.fit(xData, yData, FittingMethod=Fitting.Method.Polynomial 3, Weighting = vector [2.; 1.; 0.5.; 1.; 1.; 1.])
+    ///   
+    ///   // Estimate the intercept and slope of a line, that fits the data and ignore outliers.
+    ///   let coefficientsRobust = 
+    ///       LinearRegression.fit(xData,yData,FittingMethod=Fitting.Method.Robust Fitting.RobustEstimator.Theil)
+    /// </code> 
+    /// </example>
+    /// <remarks>Default is simple linear regression fitting without constraints.</remarks>
+    static member fit(xData: vector, yData, ?FittingMethod: Method, ?Constraint: Constraint<float*float>, ?Weighting: vector) = 
 
         let _constraint = defaultArg Constraint Unconstrained
         
@@ -877,14 +904,15 @@ type LinearRegression() =
                     LinearRegression.OrdinaryLeastSquares.Linear.RTO.fit (vector xData) (vector yData)
                 | Constraint.RegressionThroughXY coordinate -> 
                     LinearRegression.OrdinaryLeastSquares.Linear.Univariable.fitConstrained (vector xData) (vector yData) coordinate
-            | _ -> failwithf "NYI"
+            | _ -> failwithf "Weighted simple linear regression is not yet implemented! Use polynomial weighted regression with degree 1 instead."
+
         | Method.Polynomial o -> 
             match _constraint with 
             | Constraint.Unconstrained -> 
                 match Weighting with 
-                | Some w -> LinearRegression.OrdinaryLeastSquares.Polynomial.fitWithWeighting o w.Value xData yData
+                | Some w -> LinearRegression.OrdinaryLeastSquares.Polynomial.fitWithWeighting o w xData yData
                 | None -> LinearRegression.OrdinaryLeastSquares.Polynomial.fit o xData yData
-            | _ -> failwithf "NYI"
+            | _ -> failwithf "Constrained polynomial regression is not yet implemented!"
 
         | Method.Robust r -> 
             match _constraint with 
@@ -892,14 +920,39 @@ type LinearRegression() =
                 match Weighting with 
                 | None -> 
                     match r with
-                    | Theil -> LinearRegression.RobustRegression.Linear.theilEstimator xData yData
-                    | TheilSen -> LinearRegression.RobustRegression.Linear.theilSenEstimator xData yData
-                | Some w -> failwithf "NYI"
-            | _ -> failwithf "NYI"
+                    | RobustEstimator.Theil -> LinearRegression.RobustRegression.Linear.theilEstimator xData yData
+                    | RobustEstimator.TheilSen -> LinearRegression.RobustRegression.Linear.theilSenEstimator xData yData
+                | Some w -> failwithf "Weighting for robust regression is not yet implemented!"
+            | _ -> failwithf "Constrained robust regression is not yet implemented!"
 
-
-            
-
+    /// <summary>
+    ///   Determines coefficients for multivariate linear regression.
+    /// </summary>
+    /// <param name="xData">matrix of x vectors</param>
+    /// <param name="yData">vector of y values</param>
+    /// <param name="FittingMethod">Multivariate regression currently just supports Fitting.SimpleLinear (straight line).</param>
+    /// <returns>Linear regression coefficients for multivariate regression.</returns>
+    /// <example> 
+    /// <code> 
+    ///   // x vectors
+    ///   let xData = 
+    ///       matrix [
+    ///           [1.; 1. ;2.  ]
+    ///           [2.; 0.5;6.  ]
+    ///           [3.; 0.8;10. ]
+    ///           [4.; 2. ;14. ]
+    ///           [5.; 4. ;18. ]
+    ///           [6.; 3. ;22. ]
+    ///       ]
+    ///   // measured feature
+    ///   let yData = vector [107.5; 110.0; 115.7; 125.0; 137.5; 138.0]
+    ///   
+    ///   // Estimate linear coefficients for a straight line that fits the data.
+    ///   let coefficientsSimpleLinear = 
+    ///       LinearRegression.fit(xData, yData)
+    /// </code> 
+    /// </example>
+    /// <remarks>Default is simple linear regression fitting without constraints.</remarks>
     static member fit(xData: matrix, yData, ?FittingMethod: Method) = 
 
         let _fittingMethod = defaultArg FittingMethod Method.SimpleLinear
@@ -910,15 +963,33 @@ type LinearRegression() =
         | _ -> failwithf "NYI"
         
     //static member predict(coeff: LinearRegression.Coefficients, ?FittingMethod: Method) =
-    //    (fun (x: float) -> 
+    //    (fun (x: float) - 
     //        LinearRegression.OrdinaryLeastSquares.Polynomial.predict coeff x)
 
+    /// <summary>
+    ///   Creates prediction function for linear regression.
+    /// </summary>
+    /// <param name="coeff">Linear regression coefficients (e.g. from LinearRegression.fit())</param>
+    /// <param name="x">x value/vector of which the corresponding y value should be predicted</param>
+    /// <returns>Prediction function that takes an x value or x vector and predicts its corresponding y value.</returns>
+    /// <example> 
+    /// <code> 
+    ///   // e.g. days since experiment start
+    ///   let xData = vector [|1.; 2.; 3.; 4.; 5.; 6. |]
+    ///   // e.g. plant size in cm
+    ///   let yData = vector [|4.; 7.; 8.; 9.; 7.; 11.|]
+    ///   
+    ///   // Estimate the intercept and slope of a line, that fits the data.
+    ///   let coefficientsSimpleLinear = 
+    ///       LinearRegression.fit(xData,yData,FittingMethod=Fitting.Method.SimpleLinear,Constraint=Fitting.Constraint.RegressionThroughOrigin)
+    ///   
+    ///   // Predict the size on day 10.5
+    ///   LinearRegression.predict(coefficientsSimpleLinear) 10.5
+    /// </code> 
+    /// </example>
     static member predict(coeff: LinearRegression.Coefficients) =
         fun x -> 
            match box x with 
            | :? float as s -> LinearRegression.OrdinaryLeastSquares.Polynomial.predict coeff s
            | :? vector as v -> LinearRegression.OrdinaryLeastSquares.Linear.Multivariable.predict coeff v
-        
-        
-
-
+           | _ -> failwithf "Only floats or vectors are allowed as input!"

--- a/src/FSharp.Stats/Fitting/LinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/LinearRegression.fs
@@ -227,7 +227,7 @@ module LinearRegression =
                     let xTransformed = xData |> Vector.map (fun x -> x - xC)
                     let yTransformed = yData |> Vector.map (fun y -> y - yC)
                     let slope = RTO.fitOfVector xTransformed yTransformed
-                    [|- xC * slope - yC;slope|]
+                    let intercept = yC - xC * slope
 
                 
                 [<Obsolete("Use Univariable.fitConstrained instead.")>]

--- a/src/FSharp.Stats/Fitting/LogisticRegression.fs
+++ b/src/FSharp.Stats/Fitting/LogisticRegression.fs
@@ -11,21 +11,21 @@ module LogisticRegression =
     open System
     
     // Weights have 1 element more than observations, for constant
-    let private predict (weights: vector) (obs: vector) =
+    let internal predict (weights: vector) (obs: vector) =
         Vector.init (obs.Length+1) (fun i -> if i = 0 then 1. else obs.[i-1])  
         |> Vector.dot weights 
         |> FSharp.Stats.SpecialFunctions.Logistic.standard
 
-    let private error (weights: vector) (obs: vector) label =
+    let internal error (weights: vector) (obs: vector) label =
         label - predict weights obs
 
-    let private update alpha (weights: vector) (obs: vector) label =      
+    let internal update alpha (weights: vector) (obs: vector) label =      
         Vector.add weights (Vector.scale (alpha * (error weights obs label)) (Vector.init (obs.Length+1) (fun i -> if i = 0 then 1. else obs.[i-1])))
 
     // simple training: returns vector of weights
     // after fixed number of passes / iterations over dataset, 
     // with constant alpha
-    let private simpleTrain (dataset: (float * vector) seq) passes alpha =
+    let internal simpleTrain (dataset: (float * vector) seq) passes alpha =
         let rec descent iter curWeights =
             match iter with 
             | 0 -> curWeights
@@ -41,7 +41,7 @@ module LogisticRegression =
         descent passes weights
     
     // 2-Norm of Vector (length)
-    let private norm (vector: float list) = 
+    let internal norm (vector: float list) = 
         vector |> List.sumBy (fun e -> e * e) |> sqrt
 
     // rate of change in the weights vector,
@@ -57,7 +57,7 @@ module LogisticRegression =
     module Univariable = 
 
         /// Calculates the weights for logistic regression.
-        let coefficient epsilon alpha (xData : Vector<float>) (yData : Vector<float>) =
+        let fit epsilon alpha (xData : Vector<float>) (yData : Vector<float>) =
             if xData.Length <> yData.Length then
                 raise (System.ArgumentException("vector x and y have to be the same size!"))
 
@@ -83,15 +83,18 @@ module LogisticRegression =
 
             descent weights alpha
 
+        [<Obsolete("Use Univariable.fit instead.")>]
+        let coefficient epsilon alpha (xData : Vector<float>) (yData : Vector<float>) = 
+            fit epsilon alpha xData yData
 
         /// Returns the regression function
-        let fit (coef: Vector<float>) x= 
+        let predict (coef: Vector<float>) x= 
             predict coef (Vector.singleton x)
 
         let estimateAlpha epsilon (xData : Vector<float>) (yData : Vector<float>) = 
             let fR2 alpha = 
-                let weight = coefficient epsilon alpha xData yData
-                let f = fit weight
+                let weight = fit epsilon alpha xData yData
+                let f = predict weight
                 let r2 = GoodnessOfFit.calculateSSE f xData yData
                 r2
             Optimization.Brent.minimizeWith fR2 0. 1. 0.001 100
@@ -99,7 +102,7 @@ module LogisticRegression =
     module Multivariable = 
 
         /// Calculates the weights for logistic regression.
-        let coefficient epsilon alpha (xData : Matrix<float>) (yData : Vector<float>) =
+        let fit epsilon alpha (xData : Matrix<float>) (yData : Vector<float>) =
             if (xData.NumRows) <> yData.Length then
                 raise (System.ArgumentException("columns of matrix x and vector y have to be the same size!"))
 
@@ -125,12 +128,20 @@ module LogisticRegression =
 
             descent weights alpha
     
-        /// Returns the regression function
-        let fitFunc (coef: Vector<float>) = 
-            fun (x:Vector<float>) -> predict coef x
+        [<Obsolete("Use Multivariable.fit instead.")>]
+        let coefficient epsilon alpha (xData : Matrix<float>) (yData : Vector<float>) = 
+            fit epsilon alpha xData yData
 
         /// Returns the regression function
-        let fit (coef: Vector<float>) (x:Vector<float>)= 
+        let predictFunc (coef: Vector<float>) = 
+            fun (x:Vector<float>) -> predict coef x
+                
+        [<Obsolete("Use Multivariable.predictFunc instead.")>]
+        let fitFunc (coef: Vector<float>) = 
+            predictFunc coef
+
+        /// Returns the regression function
+        let predict (coef: Vector<float>) (x: Vector<float>)= 
             predict coef x
 
         //let estimateAlpha epsilon (xData : Matrix<float>) (yData : Vector<float>) = 

--- a/src/FSharp.Stats/Fitting/NonLinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/NonLinearRegression.fs
@@ -412,7 +412,7 @@ module NonLinearRegression =
             //gets the linear representation of the problem and solves it by simple linear regression
             let initialParamGuess =
                 let yLn = yData |> Array.map (fun x -> Math.Log(x)) |> vector
-                let linearReg = LinearRegression.OrdinaryLeastSquares.Linear.Univariable.coefficient (vector xData) yLn
+                let linearReg = LinearRegression.OrdinaryLeastSquares.Linear.Univariable.fit (vector xData) yLn
                 let a = exp linearReg.[0]
                 let b = linearReg.[1]
                 [|a;b|]

--- a/src/FSharp.Stats/Fitting/NonLinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/NonLinearRegression.fs
@@ -746,7 +746,7 @@ module NonLinearRegression =
                     |> fst
                 createSolverOption 0.001 0.001 10000 [|a;b;c;m|]
             
-            /// 4 parameter richards curve with minimum at 0; d <> 1
+            /// 4 parameter richards curve with minimum at 0; d &lt;&gt; 1
             let richards =
                 {
                 ParameterNames= [|"upper asymptote";"growth rate";"inflection point x";"d (influences inflection y)"|]

--- a/src/FSharp.Stats/Fitting/NonLinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/NonLinearRegression.fs
@@ -413,8 +413,8 @@ module NonLinearRegression =
             let initialParamGuess =
                 let yLn = yData |> Array.map (fun x -> Math.Log(x)) |> vector
                 let linearReg = LinearRegression.OrdinaryLeastSquares.Linear.Univariable.fit (vector xData) yLn
-                let a = exp linearReg.[0]
-                let b = linearReg.[1]
+                let a = exp linearReg.Constant
+                let b = linearReg.Linear
                 [|a;b|]
 
             {

--- a/src/FSharp.Stats/Fitting/Spline.fs
+++ b/src/FSharp.Stats/Fitting/Spline.fs
@@ -7,22 +7,22 @@ module Spline =
     open FSharp.Stats.Algebra
 
     /// Some preprocessing of the input data
-    let private preprocess (data : (float*float) []) =
+    let internal preprocess (data : (float*float) []) =
         if Array.length data < 3 then failwith "Too little input points"
         data 
         |> Seq.sortBy fst
         |> Array.ofSeq
           
-    let private preprocessBasis (data : float []) =
+    let internal preprocessBasis (data : float []) =
        if Array.length data < 3 then failwith "Too little input points"
        data |> Array.distinct |> Array.sort 
  
-    let private checkSmoothingParameter l =
+    let internal checkSmoothingParameter l =
         if l < 0. then failwith "smoothing parameter should be positive"
     
     /// Creates a smoothing spline through some data. Takes as spline points the x-values given by basispts.
     /// The resulting function takes lambda (regularization parameter) and a x_Value as input. 
-    let smoothingSpline (data: (float*float) []) (basispts : float [])=
+    let smoothingSpline (data: (float*float) []) (basispts: float []) =
         //https://robjhyndman.com/etc5410/splines.pdf
         // Some preprocessing
         let basistmp = preprocessBasis basispts

--- a/src/FSharp.Stats/Integration/Integration.fs
+++ b/src/FSharp.Stats/Integration/Integration.fs
@@ -155,7 +155,7 @@ type NumericalIntegrationMethod =
 /// Definite integral approximation
 type NumericalIntegration() = 
     
-    /// Returns a function that approximates the definite integral of the input function (float -> float) with the given `method` for partitions of equal size `partitions` in an inclusive closed interval [`intervalStart`, `intervalEnd`]
+    /// Returns a function that approximates the definite integral of the input function (float -&gt; float) with the given `method` for partitions of equal size `partitions` in an inclusive closed interval [`intervalStart`, `intervalEnd`]
     static member definiteIntegral(
         /// the numerical integration approximation method to use
         method: NumericalIntegrationMethod,

--- a/src/FSharp.Stats/Interpolation/Approximation.fs
+++ b/src/FSharp.Stats/Interpolation/Approximation.fs
@@ -11,6 +11,7 @@ module Approximation =
     type Spacing = 
         | Equally
         | Chebyshev
+
     /// <summary>
     ///   Zips x and y values, sorts them by x values and applies a given function to y values of x duplicate (like R! regularize.values).
     ///   1. pairs x-y values 
@@ -38,7 +39,7 @@ module Approximation =
         xy
 
     /// <summary>
-    ///   Return a sequence of points which interpolate the given data points by straight lines.    
+    ///   Return a sequence of points which interpolate the given data points by straight lines.
     /// </summary> 
     /// <param name="xData">unsorted x values</param>
     /// <param name="yData">y values of corresponding x values</param>

--- a/src/FSharp.Stats/Intervals.fs
+++ b/src/FSharp.Stats/Intervals.fs
@@ -177,7 +177,7 @@ module Intervals =
 
             
 
-    /// Get the value at a given percentage within (0.0 - 1.0) or outside (< 0.0, > 1.0) of the interval. Rounding to nearest neighbour occurs when needed.
+    /// Get the value at a given percentage within (0.0 - 1.0) or outside (&lt; 0.0, &gt; 1.0) of the interval. Rounding to nearest neighbour occurs when needed.
     let inline getValueAt percentage interval =        
         match trySize interval with
         | Some size -> percentage * (float size)
@@ -200,7 +200,7 @@ module Intervals =
 
 
 ///// <summary> 
-/////   Get a percentage how far inside (0.0 - 1.0) or outside (< 0.0, > 1.0) the interval a certain value lies. 
+/////   Get a percentage how far inside (0.0 - 1.0) or outside (&lt; 0.0, &gt; 1.0) the interval a certain value lies. 
 /////   For single intervals, '1.0' is returned when inside the interval, '-1.0' otherwise. 
 ///// </summary> 
 ///// <param name="position">The position value to get the percentage for.</param> 
@@ -267,7 +267,7 @@ module Intervals =
 //
 ///// <summary> 
 /////   Returns a scaled version of the current interval, but prevents the interval from exceeding the values specified in a passed limit. 
-/////   This is useful to prevent <see cref="ArgumentOutOfRangeException" /> during calculations for certain types. 
+/////   This is useful to prevent ArgumentOutOfRangeException during calculations for certain types. 
 ///// </summary> 
 ///// <param name="scale"> 
 /////   Percentage to scale the interval up or down. 

--- a/src/FSharp.Stats/ML/Unsupervised/ClusterNumber.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/ClusterNumber.fs
@@ -284,7 +284,7 @@ https://www.datanovia.com/en/lessons/determining-the-optimal-number-of-clusters-
         [<Obsolete("Use logDispersionKMeansInitRandom instead.")>]
         let logDispersionKMeans_initRandom = logDispersionKMeansInitRandom
 
-        ////[<Obsolete("Use [logDispersionKMeans_initCvMax] instead.")>]
+        ////[Obsolete("Use [logDispersionKMeans_initCvMax] instead.")]
         //// Calculate log(sum_i(within-cluster_i sum of squares around cluster_i mean)) of kmeans clustering result.
         //let logDispersionKMeans_initCvMax_old = 
         //    let aggregator = IterativeClustering.avgCentroid

--- a/src/FSharp.Stats/Random.fs
+++ b/src/FSharp.Stats/Random.fs
@@ -24,7 +24,7 @@ module Random =
                             if n >= 0 then this.rnd <- new ThreadLocal<Random>(fun () -> new Random(n))
         interface IRandom with
             member x.NextInt() = x.rnd.Value.Next()
-            ///maxValue is not part of the possible sampling range (minVal <= x < maxVal)
+            ///maxValue is not part of the possible sampling range (minVal &lt;= x &lt; maxVal)
             member x.NextInt maxValue = x.rnd.Value.Next(maxValue)
             /// Returns a random floating-point number that is greater or equal to 0.0, and less then 1.0
             member x.NextFloat() =x.rnd.Value.NextDouble()
@@ -40,7 +40,7 @@ module Random =
                          then
                             if n >= 0 then this.rnd <- new Random(n)
         interface IRandom with
-            ///maxValue is not part of the possible sampling range (minVal <= x < maxVal)
+            ///maxValue is not part of the possible sampling range (minVal &lt;= x &lt; maxVal)
             member x.NextInt() = x.rnd.Next()
             member x.NextInt maxValue = x.rnd.Next(maxValue)
             member x.NextFloat() =x.rnd.NextDouble()

--- a/src/FSharp.Stats/Signal/Padding.fs
+++ b/src/FSharp.Stats/Signal/Padding.fs
@@ -102,7 +102,7 @@ module Padding =
 
     ///Adds additional data points to the beginning and end of data set (number: borderpadding; x_Value distance: minDistance; y_Value: random).
     ///Between every pair of data point where the difference in x_Values is greater than minDistance, additional datapoints are generated as defined in internalPaddingMethod.
-    ///If huge data chunks are missing (missing gap < maxDistance), data points are added as defined in hugeGapPaddingMethod.
+    ///If huge data chunks are missing (missing gap &lt; maxDistance), data points are added as defined in hugeGapPaddingMethod.
     ///default: internalPaddingMethod=LinearInterpolation; hugeGapPaddingMethod=Random (like in border cases)
     ///getDiff: get the difference in x_Values as float representation (if 'a is float then (-))
     ///addToXValue: function that adds a float to the x_Value (if 'a is float then (+))

--- a/src/FSharp.Stats/Testing/ChiSquareTest.fs
+++ b/src/FSharp.Stats/Testing/ChiSquareTest.fs
@@ -9,7 +9,7 @@
 /// <para>
 ///   A chi-square test (also chi-squared or χ2  test) is any statistical
 ///   hypothesis test in which the sampling distribution of the test statistic
-///   is a <see cref="ChiSquareDistribution">chi-square distribution</see> when
+///   is a ChiSquareDistribution when
 ///   the null hypothesis is true, or any in which this is asymptotically true,
 ///   meaning that the sampling distribution (if the null hypothesis is true) 
 ///   can be made to approximate a chi-square distribution as closely as desired
@@ -37,7 +37,7 @@ module ChiSquareTest =
     open FSharp.Stats
 
     /// Computes the Chi-Square test
-    /// n data points -> degrees of freedom = n - 1 
+    /// n data points -&gt; degrees of freedom = n - 1 
     let compute (degreesOfFreedom:int) (expected:seq<float>) (observed:seq<float>) =
         //let chechParams =
         //    if expected |> Seq.exists (fun x -> abs x < 5.) then printfn "Warning: A value less than 5 is present in expected values. Results may not be correct!"

--- a/src/FSharp.Stats/Testing/FisherHotelling.fs
+++ b/src/FSharp.Stats/Testing/FisherHotelling.fs
@@ -1,7 +1,7 @@
 namespace FSharp.Stats.Testing
 
 
-/// Fisher-Z transformation for Pearson correlation coefficient after Hotelling (1953) for n< 50
+/// Fisher-Z transformation for Pearson correlation coefficient after Hotelling (1953) for n &lt; 50
 module FisherHotelling =
 
     open FSharp.Stats
@@ -15,7 +15,7 @@ module FisherHotelling =
         1. / sqrt(float(n-3))
 
     /// Fisher-Z transformation for Pearson correlation coefficient    
-    /// after Hotelling (1953) for n < 50
+    /// after Hotelling (1953) for n &lt; 50
     let private transformFisherHotellingZ r n =
         let hotelling r z = z - ( ( 3.*z + r) / (4.*(n-1.) ) )
         let z = transformFisherZ  r                
@@ -28,7 +28,7 @@ module FisherHotelling =
 
 
     /// Standart deviation Fisher-Z transformation for Pearson correlation coefficient
-    /// after Hotelling (1953) for n< 50
+    /// after Hotelling (1953) for n &lt; 50
     let private stdFisherHotellingZ n =
         if n < 1 then
             //printfn "Parameter warning: not n < 1"

--- a/src/FSharp.Stats/Testing/PostHoc.fs
+++ b/src/FSharp.Stats/Testing/PostHoc.fs
@@ -174,7 +174,7 @@ module PostHoc =
 
     
     /// Dunnetts post hoc test compares groups to one control group (multiple-to-one comparison). 
-    /// Returns if the groups defined in the contrast differ significantly (already multi comparison corrected for FWER<a) 
+    /// Returns if the groups defined in the contrast differ significantly (already multi comparison corrected for FWER &lt; a) 
     /// Critical value tables can be found in Testing.Tables
     let dunnetts (contrastMatrix:float[][]) (data:float[][]) (criticalTable:Matrix<float>) =
         // Sample sizes

--- a/tests/FSharp.Stats.Tests/Fitting.fs
+++ b/tests/FSharp.Stats.Tests/Fitting.fs
@@ -41,15 +41,17 @@ let leastSquaresCholeskyTests =
         testCase "Univariable Regression" (fun () ->
             let expectedCoefficients = [3.; 2.]
             let coeffcientsCholesky = LinearRegression.OrdinaryLeastSquares.Linear.Univariable.fitCholesky (vector xs) yVector
-            Expect.floatClose Accuracy.low coeffcientsCholesky.[0] expectedCoefficients.[0] "Coefficient should be equal"
-            Expect.floatClose Accuracy.low coeffcientsCholesky.[1] expectedCoefficients.[1] "Coefficient should be equal"
+            Expect.floatClose Accuracy.low coeffcientsCholesky.Constant expectedCoefficients.[0] "Coefficient should be equal"
+            Expect.floatClose Accuracy.low coeffcientsCholesky.Linear expectedCoefficients.[1] "Coefficient should be equal"
+            Expect.floatClose Accuracy.low coeffcientsCholesky.Coefficients.[1] expectedCoefficients.[1] "Coefficient should be equal"
         )
         testCase "Multivariable Regression" (fun () ->
             let expectedCoefficients = [3.; 2.; 1.]
             let coeffcientsCholesky = LinearRegression.OrdinaryLeastSquares.Linear.Multivariable.fitCholesky xData yData
-            Expect.floatClose Accuracy.low coeffcientsCholesky.[0] expectedCoefficients.[0] "Coefficient should be equal"
-            Expect.floatClose Accuracy.low coeffcientsCholesky.[1] expectedCoefficients.[1] "Coefficient should be equal"
-            Expect.floatClose Accuracy.low coeffcientsCholesky.[2] expectedCoefficients.[2] "Coefficient should be equal"
+            Expect.floatClose Accuracy.low coeffcientsCholesky.Constant expectedCoefficients.[0] "Coefficient should be equal"
+            Expect.floatClose Accuracy.low coeffcientsCholesky.Linear expectedCoefficients.[1] "Coefficient should be equal"
+            Expect.floatClose Accuracy.low coeffcientsCholesky.Quadratic expectedCoefficients.[2] "Coefficient should be equal"
+            Expect.floatClose Accuracy.low (coeffcientsCholesky.getCoefficient 2) expectedCoefficients.[2] "Coefficient should be equal"
         )
     ]
 open FSharp.Stats.Fitting.Spline

--- a/tests/FSharp.Stats.Tests/Fitting.fs
+++ b/tests/FSharp.Stats.Tests/Fitting.fs
@@ -40,13 +40,13 @@ let leastSquaresCholeskyTests =
     testList "Least Squares with Cholesky" [
         testCase "Univariable Regression" (fun () ->
             let expectedCoefficients = [3.; 2.]
-            let coeffcientsCholesky = LinearRegression.OrdinaryLeastSquares.Linear.Univariable.coefficientCholesky (vector xs) yVector
+            let coeffcientsCholesky = LinearRegression.OrdinaryLeastSquares.Linear.Univariable.fitCholesky (vector xs) yVector
             Expect.floatClose Accuracy.low coeffcientsCholesky.[0] expectedCoefficients.[0] "Coefficient should be equal"
             Expect.floatClose Accuracy.low coeffcientsCholesky.[1] expectedCoefficients.[1] "Coefficient should be equal"
         )
         testCase "Multivariable Regression" (fun () ->
             let expectedCoefficients = [3.; 2.; 1.]
-            let coeffcientsCholesky = LinearRegression.OrdinaryLeastSquares.Linear.Multivariable.coefficientsCholesky xData yData
+            let coeffcientsCholesky = LinearRegression.OrdinaryLeastSquares.Linear.Multivariable.fitCholesky xData yData
             Expect.floatClose Accuracy.low coeffcientsCholesky.[0] expectedCoefficients.[0] "Coefficient should be equal"
             Expect.floatClose Accuracy.low coeffcientsCholesky.[1] expectedCoefficients.[1] "Coefficient should be equal"
             Expect.floatClose Accuracy.low coeffcientsCholesky.[2] expectedCoefficients.[2] "Coefficient should be equal"

--- a/tests/FSharp.Stats.Tests/ML.fs
+++ b/tests/FSharp.Stats.Tests/ML.fs
@@ -320,7 +320,7 @@ module hClust =
         |> Seq.toArray
         |> Array.mapi (fun i (lable,data) -> sprintf "%s_%i" lable i, data)
         |> Array.unzip
-    let distance = DistanceMetrics.euclidean
+    let distance = FSharp.Stats.DistanceMetrics.euclidean
     let linker = Linker.singleLwLinker
     let testCluster = generate<float[]> distance linker data |> Seq.item 0 |> (fun x -> x.Key)
     let testLeaf = createClusterValue 1 [|1.;2.|]

--- a/tests/FSharp.Stats.Tests/Signal.fs
+++ b/tests/FSharp.Stats.Tests/Signal.fs
@@ -334,8 +334,8 @@ let paddingTests =
 
             let padded = Padding.pad data 1.0 Double.PositiveInfinity (-) (+) padding Padding.BorderPaddingMethod.Zero Padding.InternalPaddingMethod.NaN Padding.HugeGapPaddingMethod.NaN
 
-            Expect.equal (Array.sub padded 0 padding) expectLeadIn
-            Expect.equal (Array.sub padded (padded.Length - padding) padding) expectLeadOut
+            Expect.equal (Array.sub padded 0 padding) expectLeadIn "padding is incorrect" 
+            Expect.equal (Array.sub padded (padded.Length - padding) padding) expectLeadOut "padding is incorrect"
             Expect.equal (Array.sub padded padding data.Length) data "All the original data should be contained in the padded data"
             Expect.equal padded.Length (data.Length + 2 * padding) "Length should be the original data length plus padding at each end"
             Expect.equal (padded |> Array.sortBy fst) expectedPadded "Result should be the lead-in, whole data, then lead-out (maybe not in order?)"


### PR DESCRIPTION

closes #94

**Please list the changes introduced in this PR**

- Renamings as discussed in #94 
  - `coefficient`/`coefficients` -> `fit` 
  - `fit` -> `predict`
- `LinearRegression` type that allows the most common fitting procedures without diving deep into modules
  - e.g. `Fitting.LinearRegression.OrdinaryLeastSquares.Linear.Univariable.coefficient xData yData` becomes `Fitting.LinearRegression.fit(xData,yData,Fitting.Method.SimpleLinear)`
- XML comments for all LinearRegression functions/types/fields

**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [ ] Added unit tests regarding the added features
