### PR TITLE
Update interval type

### DIFF
--- a/docs/Interpolation.fsx
+++ b/docs/Interpolation.fsx
@@ -443,7 +443,7 @@ To reduce this overfitting you can use x axis nodes that are spaced according to
 // new x values are determined in the x axis range of the data. These should reduce overshooting behaviour.
 // since the original data consisted of 16 points, 16 nodes are initialized
 let xs_cheby = 
-    Interpolation.Approximation.chebyshevNodes (Intervals.Interval<float>.Create(0.,3.)) 16
+    Interpolation.Approximation.chebyshevNodes (Interval.CreateClosed(0.,3.)) 16
 
 // to get the corresponding y values to the xs_cheby a linear spline is generated that approximates the new y values
 let ys_cheby =

--- a/docs/Intervals.fsx
+++ b/docs/Intervals.fsx
@@ -38,7 +38,8 @@ The interval module enables working with closed intervals. A closed interval inc
 
   - $[1,2], \left\{ x | 1 \le x \le 2 \right\}$ - closed interval; 1 and 2 are _included_
   - $(1,2), \left\{ x | 1 < x < 2 \right\}$ - open interval; 1 and 2 are _excluded_
-  - $[1,2), \left\{ x | 1 \le x < 2 \right\}$ - half open interval; 1 is _included_ but 2 is _excluded_
+  - $[1,2), \left\{ x | 1 \le x < 2 \right\}$ - right open interval; 1 is _included_ but 2 is _excluded_
+  - $(1,2], \left\{ x | 1 < x \le 2 \right\}$ - left open interval; 1 is _excluded_ but 2 is _included_
 
 
 **Interval creation**
@@ -47,8 +48,17 @@ The interval module enables working with closed intervals. A closed interval inc
 open FSharp.Stats
 open Plotly.NET
 
+let myInterval = Interval.CreateLeftOpen (-3.,2.)
+
+let loi = sprintf "myInterval is: %s" (myInterval.ToString())
+
+(*** include-value:loi***)
+
+(**
+When intervals are created from sequences, always closed intervals are generated!
+*)
 let collection = [3.0; -2.0; 5.0; 1.0; -6.0; 100.0]
-let interval = Intervals.ofSeq collection
+let interval = Interval.ofSeq collection
 
 (*** include-value:interval***)
 
@@ -64,7 +74,7 @@ open Plotly.NET.StyleParam
 
 let interval01 = 
     Chart.Point([])
-    |> Chart.withShape (Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart interval,X1=Intervals.getEnd interval,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4"))
+    |> Chart.withShape (Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart interval,X1=Interval.getEnd interval,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4"))
     |> Chart.withTemplate ChartTemplates.lightMirrored
     |> Chart.withXAxisStyle ("",MinMax=(-10.,120.))
     |> Chart.withYAxisStyle ("",MinMax=(0.,5.))
@@ -83,8 +93,8 @@ interval01 |> GenericChart.toChartHTML
 *)
 
 let collectionBy = [("a",3.0); ("b",-2.0); ("c",5.0); ("d",1.0); ("e",-6.0); ("f",100.0)]
-let intervalByFst = Intervals.ofSeqBy fst collectionBy
-let intervalBySnd = Intervals.ofSeqBy snd collectionBy
+let intervalByFst = Interval.ofSeqBy fst collectionBy
+let intervalBySnd = Interval.ofSeqBy snd collectionBy
 
 (*** include-value:intervalByFst***)
 (*** include-value:intervalBySnd***)
@@ -104,15 +114,15 @@ i + j = [a+b,c+d]
 
 *)
 
-let i02 = Intervals.create 6.  8.
-let i03 = Intervals.create 5. 10.
-let addedInterval = Intervals.add i02 i03
+let i02 = Interval.CreateClosed<float> (6.,8.)
+let i03 = Interval.CreateClosed<float> (5.,10.)
+let addedInterval = Interval.add i02 i03
 
 (*** hide ***)
 let interval02 = 
-    let i1 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart i02,X1=Intervals.getEnd i02,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4")
-    let i2 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart i03,X1=Intervals.getEnd i03,Y0=3,Y1=4,FillColor=Color.fromHex "#ff7f0e")
-    let re = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart addedInterval,X1=Intervals.getEnd addedInterval,Y0=5,Y1=6,FillColor=Color.fromHex "#2ca02c")
+    let i1 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart i02,X1=Interval.getEnd i02,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4")
+    let i2 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart i03,X1=Interval.getEnd i03,Y0=3,Y1=4,FillColor=Color.fromHex "#ff7f0e")
+    let re = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart addedInterval,X1=Interval.getEnd addedInterval,Y0=5,Y1=6,FillColor=Color.fromHex "#2ca02c")
     Chart.Point([])
     |> Chart.withShapes [i1;i2;re]
     |> Chart.withTemplate ChartTemplates.lightMirrored
@@ -137,13 +147,13 @@ i - j = [a-d,b-c]
 
 *)
 
-let subInterval = Intervals.subtract i02 i03
+let subInterval = Interval.subtract i02 i03
 
 (*** hide ***)
 let interval03 = 
-    let i1 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart i02,X1=Intervals.getEnd i02,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4")
-    let i2 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart i03,X1=Intervals.getEnd i03,Y0=3,Y1=4,FillColor=Color.fromHex "#ff7f0e")
-    let re = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart subInterval,X1=Intervals.getEnd subInterval,Y0=5,Y1=6,FillColor=Color.fromHex "#2ca02c")
+    let i1 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart i02,X1=Interval.getEnd i02,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4")
+    let i2 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart i03,X1=Interval.getEnd i03,Y0=3,Y1=4,FillColor=Color.fromHex "#ff7f0e")
+    let re = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart subInterval,X1=Interval.getEnd subInterval,Y0=5,Y1=6,FillColor=Color.fromHex "#2ca02c")
     Chart.Point([])
     |> Chart.withShapes [i1;i2;re]
     |> Chart.withTemplate ChartTemplates.lightMirrored
@@ -162,15 +172,15 @@ Closed intervals include their margins. If a margin is shared between two interv
 
 *)
 
-let i04 = Intervals.create 2.  8.
-let i05 = Intervals.create 5. 10.
-let intInterval = Intervals.intersect i04 i05
+let i04 = Interval.CreateClosed<float> (2.,8.)
+let i05 = Interval.CreateClosed<float> (5.,10.)
+let intInterval = Interval.intersect i04 i05
 
 (*** hide ***)
 let interval04 = 
-    let i1 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart i04,X1=Intervals.getEnd i04,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4")
-    let i2 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart i05,X1=Intervals.getEnd i05,Y0=3,Y1=4,FillColor=Color.fromHex "#ff7f0e")
-    let re = Shape.init(ShapeType=ShapeType.Rectangle,X0=Intervals.getStart intInterval.Value,X1=Intervals.getEnd intInterval.Value,Y0=5,Y1=6,FillColor=Color.fromHex "#2ca02c")
+    let i1 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart i04,X1=Interval.getEnd i04,Y0=1,Y1=2,FillColor=Color.fromHex "#1f77b4")
+    let i2 = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart i05,X1=Interval.getEnd i05,Y0=3,Y1=4,FillColor=Color.fromHex "#ff7f0e")
+    let re = Shape.init(ShapeType=ShapeType.Rectangle,X0=Interval.getStart intInterval,X1=Interval.getEnd intInterval,Y0=5,Y1=6,FillColor=Color.fromHex "#2ca02c")
     Chart.Point([])
     |> Chart.withShapes [i1;i2;re]
     |> Chart.withTemplate ChartTemplates.lightMirrored

--- a/docs/Signal.fsx
+++ b/docs/Signal.fsx
@@ -73,15 +73,15 @@ let sampleO1 = [|45.;42.;45.5;43.;47.;51.;34.;45.;44.;46.;48.;37.;46.;|]
 
 let outlierBordersO1 = Signal.Outliers.tukey 1.5 sampleO1
 
-let lowerBorderO1 = Intervals.getStart outlierBordersO1
+let lowerBorderO1 = Interval.getStart outlierBordersO1
 // result: 37.16667
 
-let upperBorderO1 = Intervals.getEnd outlierBordersO1
+let upperBorderO1 = Interval.getEnd outlierBordersO1
 // result: 51.83333
 
 let (inside,outside) =
     sampleO1 
-    |> Array.partition (fun x -> Intervals.liesInInterval x outlierBordersO1)
+    |> Array.partition (fun x -> outlierBordersO1.liesInInterval x)
 
 let tukeyOutlierChart =
     [

--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -12,12 +12,12 @@ module Array =
                 let current = a.[index]
                 loop (index+1) (min current minimum) (max current maximum)
             else
-                Intervals.create minimum maximum          
+                Interval.CreateClosed<'a> (minimum,maximum)
         //Init by fist value
         if a.Length > 1 then
             loop 1 a.[0] a.[0] 
         else
-            Intervals.Interval.Empty
+            Interval.Empty
 
 
     // Swaps items of left and right index

--- a/src/FSharp.Stats/ConfidenceInterval.fs
+++ b/src/FSharp.Stats/ConfidenceInterval.fs
@@ -16,4 +16,4 @@ module ConfidenceInterval =
     let ci ciLevel (sample : seq<float>)=
         let mean  = Seq.mean  sample
         let delta = ciDeviation ciLevel sample
-        Intervals.create (mean - delta) (mean + delta)
+        Interval.CreateClosed<float> ((mean - delta),(mean + delta))

--- a/src/FSharp.Stats/Distributions/Bandwidth.fs
+++ b/src/FSharp.Stats/Distributions/Bandwidth.fs
@@ -46,7 +46,7 @@ module Bandwidth =
             |> Seq.filter (fun v -> not (isInf v))
 
         let interval = Seq.range data' 
-        let dmin,dmax = Intervals.values interval
+        let dmin,dmax = Interval.values interval
         
         fromBinNumber dmin dmax (float(Seq.length(data)))
         

--- a/src/FSharp.Stats/Distributions/Continuous/ChiSquared.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/ChiSquared.fs
@@ -84,7 +84,7 @@ type ChiSquared =
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support dof =
         ChiSquared.CheckParam dof
-        Intervals.create 0. System.Double.PositiveInfinity
+        Interval.CreateClosed<float> (0.,System.Double.PositiveInfinity)
 
 
     /// A string representation of the distribution.

--- a/src/FSharp.Stats/Distributions/Continuous/Exponential.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Exponential.fs
@@ -90,7 +90,7 @@ type Exponential =
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support lambda =
         Exponential.CheckParam lambda
-        Intervals.create 0.0 System.Double.PositiveInfinity
+        Interval.CreateClosed<float> (0.0,System.Double.PositiveInfinity)
 
 
     /// A string representation of the distribution.

--- a/src/FSharp.Stats/Distributions/Continuous/Uniform.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Uniform.fs
@@ -78,7 +78,7 @@ type Uniform =
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support min max =
         Uniform.CheckParam min max
-        Intervals.create min max
+        Interval.CreateClosed<float> (min,max)
 
     /// A string representation of the distribution.
     static member ToString min max =

--- a/src/FSharp.Stats/Distributions/Discrete/Bernoulli.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Bernoulli.fs
@@ -94,7 +94,7 @@ type Bernoulli =
     /// Returns the support of the bernoulli distribution: {0, 1}.
     static member Support p =
         Bernoulli.CheckParam p
-        Intervals.create 0 1 
+        Interval.CreateClosed<int> (0,1) 
 
     /// A string representation of the distribution.
     static member ToString p =

--- a/src/FSharp.Stats/Distributions/Discrete/Binomial.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Binomial.fs
@@ -119,7 +119,7 @@ type Binomial =
     /// Returns the support of the Binomial distribution: (0., n).
     static member Support p n =
         Binomial.CheckParam p n
-        Intervals.create 0 n
+        Interval.CreateClosed<int> (0,n)
 
 
     /// A string representation of the distribution.

--- a/src/FSharp.Stats/Distributions/Discrete/Hypergeometric.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Hypergeometric.fs
@@ -150,7 +150,7 @@ type Hypergeometric =
     /// Returns the support of the hypergeometric distribution: (0., Positive Infinity).
     static member Support N K n =
         Hypergeometric.CheckParam N K n
-        Intervals.create (max 0 (n + K - N) ) (min K n)
+        Interval.CreateClosed<int> ((max 0 (n + K - N) ),(min K n))
 
 
     

--- a/src/FSharp.Stats/Distributions/Discrete/Poisson.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Poisson.fs
@@ -141,7 +141,7 @@ type Poisson =
     /// Returns the support interval for this distribution.
     static member Support lambda =
         Poisson.CheckParam lambda
-        Intervals.create 0 System.Int32.MaxValue
+        Interval.CreateClosed<int> (0,System.Int32.MaxValue)
 
     /// A string representation of the distribution.
     static member ToString lambda =

--- a/src/FSharp.Stats/Distributions/KernelDensity.fs
+++ b/src/FSharp.Stats/Distributions/KernelDensity.fs
@@ -133,7 +133,7 @@ module KernelDensity =
     
 
     let estimateWithWeight weights kernel bandwidth data =
-        let _from,_to = Array.range data |> Intervals.values
+        let _from,_to = Array.range data |> Interval.values
         estimateWith 3 _from _to 512 weights kernel bandwidth data
 
     
@@ -143,7 +143,7 @@ module KernelDensity =
 
 
     let estimate kernel bandwidth data =
-        let _from,_to = Array.range data |> Intervals.values
+        let _from,_to = Array.range data |> Interval.values
         let weights = Array.create data.Length (1./float data.Length)
         estimateWith 3 _from _to 512 weights kernel bandwidth data
 

--- a/src/FSharp.Stats/FSharp.Stats.fsproj
+++ b/src/FSharp.Stats/FSharp.Stats.fsproj
@@ -35,7 +35,7 @@
     <Compile Include="Ops.fs" />
     <Compile Include="Random.fs" />
     <Compile Include="ServiceLocator.fs" />
-    <Compile Include="Intervals.fs" />
+    <Compile Include="Interval.fs" />
     <Compile Include="Permutation.fs" />
     <Compile Include="BigRational.fs" />
     <Compile Include="INumeric.fs" />

--- a/src/FSharp.Stats/Interpolation.fs
+++ b/src/FSharp.Stats/Interpolation.fs
@@ -1480,7 +1480,7 @@ module Interpolation =
         /// <param name="n">number of points that should be placed within the interval (incl. start and end)</param>
         /// <returns>Collection of chebyshev spaced x values.</returns>
         /// <remarks>www.mscroggs.co.uk/blog/57</remarks>
-        let chebyshevNodes (interval: Intervals.Interval<float>) n = 
+        let chebyshevNodes (interval: Interval<float>) n = 
             let center = 0.5 * (interval.TryStart.Value + interval.TryEnd.Value)
             let halfrange = 0.5 * (interval.TryEnd.Value - interval.TryStart.Value) 
             Array.init n (fun i -> 
@@ -1495,8 +1495,8 @@ module Interpolation =
         /// <param name="interval">start and end value of interpolation range</param>
         /// <param name="n">number of points that should be placed within the interval (incl. start and end)</param>
         /// <returns>Collection of equally spaced x values.</returns>
-        let equalNodes (interval: Intervals.Interval<float>) n = 
-            let range = Intervals.getSize interval
+        let equalNodes (interval: Interval<float>) n = 
+            let range = Interval.getSize interval
             Vector.init n (fun k -> interval.TryStart.Value + float k * range / (float n - 1.))
     
 
@@ -1511,7 +1511,7 @@ module Interpolation =
         /// <param name="n">number of points that should be placed within the interval (incl. start and end)</param>
         /// <param name="spacing">X values can be spaced equally or according to chebyshev.</param>
         /// <returns>Coefficients for polynomial interpolation. Use Polynomial.fit to predict function values.</returns>
-        static member approxWithPolynomial (f: float -> float,i: Intervals.Interval<float>,n: int,spacing: Approximation.Spacing) = 
+        static member approxWithPolynomial (f: float -> float,i: Interval<float>,n: int,spacing: Approximation.Spacing) = 
             match spacing with
             | Approximation.Equally -> 
                 let xVal = Approximation.equalNodes i n 
@@ -1534,14 +1534,14 @@ module Interpolation =
         static member approxWithPolynomialFromValues (xData: seq<float>,yData: seq<float>,n: int,spacing: Approximation.Spacing) = 
             match spacing with
             | Approximation.Equally -> 
-                let i = Intervals.ofSeq xData
+                let i = Interval.ofSeq xData
                 let linearSplineCoeff = LinearSpline.interpolate (Array.ofSeq xData) (Array.ofSeq yData)
                 let f = LinearSpline.predict linearSplineCoeff
                 let xVal = Approximation.equalNodes i n 
                 let yVal = Vector.map f xVal
                 Polynomial.interpolate xVal yVal
             | Approximation.Chebyshev ->    
-                let i = Intervals.ofSeq xData
+                let i = Interval.ofSeq xData
                 let linearSplineCoeff = LinearSpline.interpolate (Array.ofSeq xData) (Array.ofSeq yData)
                 let f = LinearSpline.predict linearSplineCoeff
                 let xVal = Approximation.chebyshevNodes i n 

--- a/src/FSharp.Stats/Intervals.fs
+++ b/src/FSharp.Stats/Intervals.fs
@@ -3,6 +3,7 @@
 open System
 
 module Intervals =
+
     /// Closed interval [Start,End]
     type Interval<'a> = 
         | ClosedInterval of 'a * 'a
@@ -18,7 +19,30 @@ module Intervals =
             | ClosedInterval (_,max) -> Some max
             | Empty -> None
 
-        static member inline Create (min,max) = ClosedInterval (min,max)
+        member inline this.TryToTuple = 
+            match this with 
+            | ClosedInterval (min,max) -> Some (min,max)
+            | Empty -> None
+
+        member inline this.ToTuple() = 
+            match this with 
+            | ClosedInterval (min,max) -> (min,max)
+            | Empty -> failwithf "Interval was empty!"
+        
+        member inline this.GetStart() = 
+            match this with
+            | ClosedInterval (min,_) -> min
+            | Empty -> failwithf "Interval was empty!"
+        
+        member inline this.GetEnd() = 
+            match this with
+            | ClosedInterval (_,max) -> max
+            | Empty -> failwithf "Interval was empty!"
+
+        static member inline Create (min,max) =     
+            if min > max then failwithf "Interval start must be lower than interval end!"
+            ClosedInterval (min,max)
+
 
     /// Creates closed interval [min,max] by given min and max
     let inline create min max =
@@ -190,7 +214,11 @@ module Intervals =
         | ClosedInterval (min,max) -> value >= min && value <= max                                      
         | Empty -> false        
         
-        
+type Intervals<'a> =
+
+    static member a = 2.
+    
+
 // ####################################################
 
 // interval tree

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -8,11 +8,11 @@ module List =
         let rec loop l (minimum) (maximum) =
             match l with
             | h::t -> loop t (min h minimum) (max h maximum)
-            | [] -> Intervals.create minimum maximum          
+            | [] -> Interval.CreateClosed<'a> (minimum,maximum)
         //Init by fist value
         match items with
         | h::t  -> loop t h h
-        | [] -> Intervals.Interval.Empty
+        | [] -> Interval.Empty
 
     /// computes the population mean (normalized by n)
     let inline mean (items: 'T list) =

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -7,19 +7,19 @@ module Seq =
 
     module OpsS = SpecializedGenericImpl
 
-    let range (items:seq<_>) =
+    let inline range (items:seq<_>) =
         use e = items.GetEnumerator()
         let rec loop (minimum) (maximum) =
             match e.MoveNext() with
             | true  -> loop (min e.Current minimum) (max e.Current maximum)
-            | false -> Intervals.create minimum maximum          
+            | false -> Interval.CreateClosed<'a> (minimum,maximum)
         //Init by fist value
         match e.MoveNext() with
         | true  -> loop e.Current e.Current
-        | false -> Intervals.Interval.Empty
+        | false -> Interval.Empty
 
 
-    let rangeBy f (items:seq<_>) =
+    let inline rangeBy f (items:seq<_>) =
         use e = items.GetEnumerator()
         let rec loop minimum maximum minimumV maximumV =
             match e.MoveNext() with
@@ -28,13 +28,13 @@ module Seq =
                 let mmin,mminV = if current < minimum then current,e.Current else minimum,minimumV
                 let mmax,mmaxV = if current > maximum then current,e.Current else maximum,maximumV
                 loop mmin mmax mminV mmaxV
-            | false -> Intervals.create minimumV maximumV          
+            | false -> Interval.CreateClosed<'a> (minimumV,maximumV)
         //Init by fist value
         match e.MoveNext() with
         | true  -> 
             let current = f e.Current
             loop current current e.Current e.Current
-        | false -> Intervals.Interval.Empty
+        | false -> Interval.Empty
 
 
     // #region means

--- a/src/FSharp.Stats/Signal/Outliers.fs
+++ b/src/FSharp.Stats/Signal/Outliers.fs
@@ -11,7 +11,7 @@ module Outliers =
         let firstQ = Quantile.compute 0.25 d
         let thirdQ = Quantile.compute 0.75 d 
         let iqr = System.Math.Abs (thirdQ - firstQ)
-        Intervals.create (firstQ - k * iqr) (thirdQ + k * iqr) 
+        Interval.CreateClosed<float> ((firstQ - k * iqr),(thirdQ + k * iqr))
         
         
     /// Returns Z Score for an individual point. 
@@ -32,7 +32,7 @@ module Outliers =
     let populationIntervalByZScore (minZ:float) (maxZ:float) (ls:list<float>) =
         let m = List.mean ls
         let s = stDevPopulation(ls)
-        Intervals.create (minZ * s + m) (maxZ * s + m)
+        Interval.CreateClosed<float> ((minZ * s + m),(maxZ * s + m))
     
     ///Returns a list of Z scores of a sample
     let zScoresOfSample (ls:list<float>) =
@@ -44,7 +44,7 @@ module Outliers =
     let sampleIntervalByZscore (minZ:float) (maxZ:float) (ls:list<float>) =
         let m = List.mean ls
         let s = stDev(ls)
-        Intervals.create (minZ * s + m) (maxZ * s + m)
+        Interval.CreateClosed<float> ((minZ * s + m),(maxZ * s + m))
 
     ///Returns Mahalanobi's distance for an individual observation in a matrix.
     ///dataSource - Sample or Population.

--- a/src/FSharp.Stats/Vector.fs
+++ b/src/FSharp.Stats/Vector.fs
@@ -290,12 +290,12 @@ module Vector =
                 let current = items.[index]
                 loop (index+1) (min current minimum) (max current maximum)
             else
-                Intervals.create minimum maximum          
+                Interval.CreateClosed<'a> (minimum,maximum)
         //Init by fist value
         if items.Length > 1 then
             loop 1 items.[0] items.[0] 
         else
-            Intervals.Interval.Empty
+            Interval.Empty
 
     /// Computes the population mean (Normalized by N)            
     let inline mean (items:Vector<'T>) = 

--- a/tests/FSharp.Stats.Tests/ConfidenceInterval.fs
+++ b/tests/FSharp.Stats.Tests/ConfidenceInterval.fs
@@ -21,8 +21,8 @@ let ci =
             let ex_min = -0.414473646404
             let ex_max =  0.8861069797373
             let ac_interval = ConfidenceInterval.ci 0.95 xs
-            let ac_min = Intervals.getStart ac_interval
-            let ac_max = Intervals.getEnd ac_interval
+            let ac_min = Interval.getStart ac_interval
+            let ac_max = Interval.getEnd ac_interval
             Expect.floatClose Accuracy.medium ac_min ex_min "Should be equal (double precision)"
             Expect.floatClose Accuracy.medium ac_max ex_max "Should be equal (double precision)"
 
@@ -30,8 +30,8 @@ let ci =
             let ex_min = 0.21914192348
             let ex_max = 0.2524914098533
             let ac_interval = ConfidenceInterval.ci 0.05 xs
-            let ac_min = Intervals.getStart ac_interval
-            let ac_max = Intervals.getEnd ac_interval
+            let ac_min = Interval.getStart ac_interval
+            let ac_max = Interval.getEnd ac_interval
             Expect.floatClose Accuracy.high ac_min ex_min "Should be equal (double precision)"
             Expect.floatClose Accuracy.high ac_max ex_max "Should be equal (double precision)"
     ]

--- a/tests/FSharp.Stats.Tests/Interval.fs
+++ b/tests/FSharp.Stats.Tests/Interval.fs
@@ -289,6 +289,88 @@ let intervalTests =
                 Interval.isIntersection i1 i2
             let expectedStrT = true
             Expect.equal actualStrT expectedStrT "String intervals do intersect"
+
+            
+            let i1 = Interval.CreateOpen<float> (1.,2.)
+            let i2 = Interval.CreateOpen<float> (2.,3.)
+            let i3 = Interval.CreateClosed<float> (2.,3.)
+            let i4 = Interval.CreateClosed<float> (3.,4.)
+            let i5 = Interval.CreateLeftOpen<float> (2.,3.)
+            let i6 = Interval.CreateLeftOpen<float> (1.,2.)
+            let i7 = Interval.CreateRightOpen<float> (2.,3.)
+            let i8 = Interval.CreateRightOpen<float> (3.,4.)
+            
+            Expect.equal (Interval.isIntersection i1 i1) true  "(i1 i1) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i1 i2) false "(i1 i2) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i1 i3) false "(i1 i3) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i1 i4) false "(i1 i4) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i1 i5) false "(i1 i5) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i1 i6) true  "(i1 i6) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i1 i7) false "(i1 i7) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i1 i8) false "(i1 i8) Intervals do not intersect"
+
+            Expect.equal (Interval.isIntersection i2 i1) false "(i2 i1) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i2 i2) true  "(i2 i2) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i2 i3) true  "(i2 i3) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i2 i4) false "(i2 i4) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i2 i5) true  "(i2 i5) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i2 i6) false "(i2 i6) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i2 i7) true  "(i2 i7) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i2 i8) false "(i2 i8) Intervals do not intersect"
+
+            Expect.equal (Interval.isIntersection i3 i1) false "(i3 i1) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i3 i2) true  "(i3 i2) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i3 i3) true  "(i3 i3) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i3 i4) true  "(i3 i4) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i3 i5) true  "(i3 i5) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i3 i6) true  "(i3 i6) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i3 i7) true  "(i3 i7) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i3 i8) true  "(i3 i8) Intervals do intersect"
+            
+            Expect.equal (Interval.isIntersection i4 i1) false "(i4 i1) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i4 i2) false "(i4 i2) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i4 i3) true  "(i4 i3) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i4 i4) true  "(i4 i4) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i4 i5) true  "(i4 i5) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i4 i6) false "(i4 i6) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i4 i7) false "(i4 i7) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i4 i8) true  "(i4 i8) Intervals do intersect"
+
+            Expect.equal (Interval.isIntersection i5 i1) false "(i5 i1) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i5 i2) true  "(i5 i2) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i5 i3) true  "(i5 i3) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i5 i4) true  "(i5 i4) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i5 i5) true  "(i5 i5) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i5 i6) false "(i5 i6) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i5 i7) true  "(i5 i7) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i5 i8) true  "(i5 i8) Intervals do intersect"
+
+            Expect.equal (Interval.isIntersection i6 i1) true "(i6 i1) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i6 i2) false "(i6 i2) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i6 i3) true  "(i6 i3) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i6 i4) false "(i6 i4) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i6 i5) false "(i6 i5) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i6 i6) true  "(i6 i6) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i6 i7) true  "(i6 i7) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i6 i8) false "(i6 i8) Intervals do not intersect"
+
+            Expect.equal (Interval.isIntersection i7 i1) false "(i7 i1) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i7 i2) true  "(i7 i2) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i7 i3) true  "(i7 i3) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i7 i4) false "(i7 i4) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i7 i5) true  "(i7 i5) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i7 i6) true  "(i7 i6) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i7 i7) true  "(i7 i7) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i7 i8) false "(i7 i8) Intervals do not intersect"
+
+            Expect.equal (Interval.isIntersection i8 i1) false "(i8 i1) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i8 i2) false "(i8 i2) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i8 i3) true  "(i8 i3) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i8 i4) true  "(i8 i4) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i8 i5) true  "(i8 i5) Intervals do intersect"
+            Expect.equal (Interval.isIntersection i8 i6) false "(i8 i6) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i8 i7) false "(i8 i7) Intervals do not intersect"
+            Expect.equal (Interval.isIntersection i8 i8) true  "(i8 i8) Intervals do intersect"
             )
 
         
@@ -298,56 +380,56 @@ let intervalTests =
                 let i1 = Interval.CreateClosed<float> (-5.,5.5)
                 let i2 = Interval.CreateClosed<float> (-3.,0.)
                 Interval.intersect i1 i2
-            let expected = Some (Interval.CreateClosed<float> (-3.,0.))
+            let expected = (Interval.CreateClosed<float> (-3.,0.))
             Expect.equal actual expected "Interval intersect is calculated incorrectly"
 
             let actualFalse = 
                 let i1 = Interval.CreateClosed<float> (-5.,5.5)
                 let i2 = Interval.CreateClosed<float> (-infinity,-6.)
                 Interval.intersect i1 i2
-            let expectedFalse = None
-            Expect.equal actual expected "Interval intersect is calculated incorrectly"
+            let expectedFalse = Interval.Empty
+            Expect.equal actualFalse expectedFalse "Interval intersect is calculated incorrectly"
 
             let actual2 = 
                 let i1 = Interval.CreateClosed<float> (-5.,5.5)
                 let i2 = Interval.CreateClosed<float> (-infinity,2.)
                 Interval.intersect i1 i2
-            let expected2 = Some (Interval.CreateClosed<float> (-5.,2.))
+            let expected2 = Interval.CreateClosed<float> (-5.,2.)
             Expect.equal actual2 expected2 "Intervals do intersect"
             
             let actualCE = 
                 let i1 = Interval.CreateClosed<float> (-5.,5.5)
                 let i2 = Interval.Empty
                 Interval.intersect i1 i2
-            let expectedCE = None
+            let expectedCE = Interval.Empty
             Expect.equal actualCE expectedCE "Intervals do not intersect"
             
             let actualEC = 
                 let i1 = Interval.Empty
                 let i2 = Interval.CreateClosed<float> (-3.,0.)
                 Interval.intersect i1 i2
-            let expectedEC = None
+            let expectedEC = Interval.Empty
             Expect.equal actualEC expectedEC "Empty intervals do not intersect"
             
             let actualEE = 
                 let i1 = Interval.Empty
                 let i2 = Interval.Empty
                 Interval.intersect i1 i2
-            let expectedEE = Some Interval.Empty
+            let expectedEE = Interval.Empty
             Expect.equal actualEE expectedEE "Empty intervals do intersect"
             
             let actualStr = 
                 let i1 = Interval.CreateClosed<string> ("a","d")
                 let i2 = Interval.CreateClosed<string> ("de","e")
                 Interval.intersect i1 i2
-            let expectedStr = None
+            let expectedStr = Interval.Empty
             Expect.equal actualStr expectedStr "String intervals do not intersect"
             
             let actualStrT = 
                 let i1 = Interval.CreateClosed<string> ("a","d")
                 let i2 = Interval.CreateClosed<string> ("d","e")
                 Interval.intersect i1 i2
-            let expectedStrT = Some (Interval.CreateClosed<string> ("d","d"))
+            let expectedStrT = Interval.CreateClosed<string> ("d","d")
             Expect.equal actualStrT expectedStrT "String intervals do intersect"
             )
 

--- a/tests/FSharp.Stats.Tests/Interval.fs
+++ b/tests/FSharp.Stats.Tests/Interval.fs
@@ -27,7 +27,7 @@ let intervalTests =
             let actual = Interval.ofSeq [3.;-0.;-5.;0.;0.;5.]
             Expect.equal actual expected "Wrong interval was extracted from sequence"
 
-            let expectedInt = Interval.Closed (-5,5)
+            let expectedInt = Interval.Closed (5,5)
             let actualInt = Interval.ofSeq [5;5;5;5;5;]
             Expect.equal actualInt expectedInt "Wrong interval was extracted from sequence"
 
@@ -54,239 +54,239 @@ let intervalTests =
             let actualStr = Interval.ofSeq ["asd";"bcd";"aavbsd";"z"]
             Expect.equal actualStr expectedStr "Interval of strings is incorrect"
             
-            let expectedChar = Intervals.create 'f' 'r'
-            let actualChar = Intervals.ofSeq ['g';'f';'q';'q';'r';]
+            let expectedChar = Interval.CreateClosed<char> ('f','r')
+            let actualChar = Interval.ofSeq ['g';'f';'q';'q';'r';]
             Expect.equal actualChar expectedChar "Interval of chars is incorrect"
         )
         
         testCase "ofSeqBy" (fun _ -> 
-            let expected = Intervals.create (3,-5.) (6,5.)
-            let actual = Intervals.ofSeqBy snd [0,3.;1,5;2,-0.;3,-5.;4,0.;5,0.;6,5.]
+            let expected = Interval.CreateClosed<int*float> ((3,-5.),(6,5.))
+            let actual = Interval.ofSeqBy snd [0,3.;1,5;2,-0.;3,-5.;4,0.;5,0.;6,5.]
             Expect.equal actual expected "Wrong interval was extracted from indexed sequence"
             
-            let expectedInt = Intervals.create (0,5) (4,5)
-            let actualInt = Intervals.ofSeqBy snd (List.indexed [5;5;5;5;5;])
+            let expectedInt = Interval.CreateClosed<int*int> ((0,5),(4,5))
+            let actualInt = Interval.ofSeqBy snd (List.indexed [5;5;5;5;5;])
             Expect.equal actualInt expectedInt "Wrong interval was extracted from sequence"
 
-            let nanCase() = Intervals.ofSeqBy snd (List.indexed [3.;nan;-0.;-5.;0.;0.;5.]) |> ignore
+            let nanCase() = Interval.ofSeqBy snd (List.indexed [3.;nan;-0.;-5.;0.;0.;5.]) |> ignore
             Expect.throws nanCase "collections containing nan should fail to return a valid interval"
         
-            let expectedInf = Intervals.create (3,-5.) (4,infinity)
-            let actualInf = Intervals.ofSeqBy snd (List.indexed [3.;infinity;-0.;-5.;infinity;0.;0.;5.])
+            let expectedInf = Interval.CreateClosed<int*float> ((3,-5.),(4,infinity))
+            let actualInf = Interval.ofSeqBy snd (List.indexed [3.;infinity;-0.;-5.;infinity;0.;0.;5.])
             Expect.equal actualInf expectedInf "infinity should be upper margin of interval"
         
-            let expectedInfNeg = Intervals.create (1,-infinity) (7,5.)
-            let actualInfNeg = Intervals.ofSeqBy snd (List.indexed [3.;-infinity;-0.;-5.;0.;0.;-infinity;5.])
+            let expectedInfNeg = Interval.CreateClosed<int*float> ((1,-infinity),(7,5.))
+            let actualInfNeg = Interval.ofSeqBy snd (List.indexed [3.;-infinity;-0.;-5.;0.;0.;-infinity;5.])
             Expect.equal actualInfNeg expectedInfNeg "-infinity should be lower margin of interval"
         
-            let expectedInfs = Intervals.create (6,-infinity) (1,infinity)
-            let actualInfs = Intervals.ofSeqBy snd (List.indexed [3.;infinity;-0.;-5.;0.;0.;-infinity;5.])
+            let expectedInfs = Interval.CreateClosed<int*float> ((6,-infinity),(1,infinity))
+            let actualInfs = Interval.ofSeqBy snd (List.indexed [3.;infinity;-0.;-5.;0.;0.;-infinity;5.])
             Expect.equal actualInfs expectedInfs "-infinity and infinity should be interval margins"
             
-            let expectedEmpty = Intervals.Interval.Empty
-            let actualEmpty = Intervals.ofSeqBy snd []
+            let expectedEmpty = Interval.Empty
+            let actualEmpty = Interval.ofSeqBy snd []
             Expect.equal actualEmpty expectedEmpty "Interval should be empty"
             
-            let expectedStr = Intervals.create (2,"a") (4,"zz")
-            let actualStr = Intervals.ofSeqBy snd (List.indexed ["asd";"bcd";"a";"z";"zz";"aavbsd"])
+            let expectedStr = Interval.CreateClosed<int*string> ((2,"a"),(4,"zz"))
+            let actualStr = Interval.ofSeqBy snd (List.indexed ["asd";"bcd";"a";"z";"zz";"aavbsd"])
             Expect.equal actualStr expectedStr "Interval of strings is incorrect"
             
-            let expectedChar = Intervals.create (1,'f') (5,'r')
-            let actualChar = Intervals.ofSeqBy snd (List.indexed  ['g';'f';'q';'q';'r';'r'])
+            let expectedChar = Interval.CreateClosed<int*char> ((1,'f'),(5,'r'))
+            let actualChar = Interval.ofSeqBy snd (List.indexed  ['g';'f';'q';'q';'r';'r'])
             Expect.equal actualChar expectedChar "Interval of chars is incorrect"
         )
 
         testCase "values" (fun _ -> 
             let expected = 
-                Intervals.create (-5.) (5.)
-                |> Intervals.values
+                Interval.CreateClosed<float> (-5.,5.)
+                |> Interval.values
             let actual = (-5.,5.)
             Expect.equal actual expected "Interval value assessment is incorrect"
             
             let expectedEmpty() = 
-                Intervals.Interval.Empty
-                |> Intervals.values
+                Interval.Empty
+                |> Interval.values
                 |> ignore
             Expect.throws expectedEmpty "Empty intervals cannot have values"
             )
 
         testCase "getStart" (fun _ -> 
             let expected = 
-                Intervals.create (-5.) (5.)
-                |> Intervals.getStart
+                Interval.CreateClosed<float> (-5.,5.)
+                |> Interval.getStart
             let actual = -5.
             Expect.equal actual expected "Interval minimum assessment is incorrect"
             
             let expectedEmpty() = 
-                Intervals.Interval.Empty
-                |> Intervals.getStart
+                Interval.Empty
+                |> Interval.getStart
                 |> ignore
             Expect.throws expectedEmpty "Empty intervals cannot have starts"
             )
 
         testCase "getEnd" (fun _ -> 
             let actual = 
-                Intervals.create (-5.) (5.)
-                |> Intervals.getEnd
+                Interval.CreateClosed<float> (-5.,5.)
+                |> Interval.getEnd
             let expected = 5.
             Expect.equal actual expected "Interval maximum assessment is incorrect"
             
             let expectedEmpty() = 
-                Intervals.Interval.Empty
-                |> Intervals.getEnd
+                Interval.Empty
+                |> Interval.getEnd
                 |> ignore
             Expect.throws expectedEmpty "Empty intervals cannot have ends"
             )
 
         testCase "getSize" (fun _ -> 
             let actual = 
-                Intervals.create (-5.) (5.5)
-                |> Intervals.getSize
+                Interval.CreateClosed<float> (-5.,5.5)
+                |> Interval.getSize
             let expected = 10.5
             Expect.equal actual expected "Interval size calculation is incorrect"
             
             let expectedEmpty() = 
-                Intervals.Interval.Empty
-                |> Intervals.getSize
+                Interval.Empty
+                |> Interval.getSize
                 |> ignore
             Expect.throws expectedEmpty "Empty intervals cannot have have a size"
             )
 
         testCase "getSizeBy" (fun _ -> 
             let actual = 
-                Intervals.create ("a",-5.) ("b",5.5)
-                |> Intervals.getSizeBy snd
+                Interval.CreateClosed<string*float> (("a",-5.),("b",5.5))
+                |> Interval.getSizeBy snd
             let expected = 10.5
             Expect.equal actual expected "Interval size calculation is incorrect"
             
             let expectedEmpty() = 
-                Intervals.Interval.Empty
-                |> Intervals.getSizeBy id
+                Interval.Empty
+                |> Interval.getSizeBy id
                 |> ignore
             Expect.throws expectedEmpty "Empty intervals cannot have a size"
             )
 
         testCase "trySize" (fun _ -> 
             let actual = 
-                Intervals.create (-5.) (5.5)
-                |> Intervals.trySize
+                Interval.CreateClosed<float> (-5.,5.5)
+                |> Interval.trySize
             let expected = Some 10.5
             Expect.equal actual expected "Size of interval is incorrect"
             
             let expectedEmpty = 
-                Intervals.Interval.Empty
-                |> Intervals.trySize
+                Interval.Empty
+                |> Interval.trySize
             Expect.equal expectedEmpty None "Empty intervals have no size"
             )
 
         testCase "add" (fun _ -> 
             let actual = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.create (0.) (-3.)
-                Intervals.add i1 i2
-            let expected = Intervals.create (-5.) (2.5)
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.CreateClosed<float> (0.,3.)
+                Interval.add i1 i2
+            let expected = Interval.CreateClosed<float> (-5.,8.5)
             Expect.equal actual expected "Interval addition is incorrect"
             
             let actualCE = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.Interval.Empty
-                Intervals.add i1 i2
-            let expectedCE = Intervals.create (-5.) (5.5)
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.Empty
+                Interval.add i1 i2
+            let expectedCE = Interval.CreateClosed<float> (-5.,5.5)
             Expect.equal actualCE expectedCE "Interval addition of Empty intervals is incorrect"
             
             let actualEC = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.create (0.) (-3.)
-                Intervals.add i1 i2
-            let expectedEC = Intervals.create (0.) (-3.)
+                let i1 = Interval.Empty
+                let i2 = Interval.CreateClosed<float> (0.,3.)
+                Interval.add i1 i2
+            let expectedEC = Interval.CreateClosed<float> (0.,3.)
             Expect.equal actualEC expectedEC "Interval addition of Empty intervals is incorrect"
             
             let actualEE = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.Interval.Empty
-                Intervals.add i1 i2
-            let expectedEE = Intervals.Interval.Empty
+                let i1 = Interval.Empty
+                let i2 = Interval.Empty
+                Interval.add i1 i2
+            let expectedEE = Interval.Empty
             Expect.equal actualEE expectedEE "Interval addition of Empty intervals is incorrect"
             )
 
         testCase "subtract" (fun _ -> 
             let actual = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.create (-3.) (0.)
-                Intervals.subtract i1 i2
-            let expected = Intervals.create (-5.) (8.5)
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.CreateClosed<float> (-3.,0.)
+                Interval.subtract i1 i2
+            let expected = Interval.CreateClosed<float> (-5.,8.5)
             Expect.equal actual expected "Interval subtraction is incorrect"
             
             let actualCE = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.Interval.Empty
-                Intervals.subtract i1 i2
-            let expectedCE = Intervals.create (-5.) (5.5)
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.Empty
+                Interval.subtract i1 i2
+            let expectedCE = Interval.CreateClosed<float> (-5.,5.5)
             Expect.equal actualCE expectedCE "Interval subtraction of Empty intervals is incorrect"
             
             let actualEC = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.create (-3.) (0.)
-                Intervals.subtract i1 i2
-            let expectedEC = Intervals.create (-3.) (0.)
+                let i1 = Interval.Empty
+                let i2 = Interval.CreateClosed<float> (-3.,0.)
+                Interval.subtract i1 i2
+            let expectedEC = Interval.CreateClosed<float> (-3.,0.)
             Expect.equal actualEC expectedEC "Interval subtraction of Empty intervals is incorrect"
             
             let actualEE = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.Interval.Empty
-                Intervals.subtract i1 i2
-            let expectedEE = Intervals.Interval.Empty
+                let i1 = Interval.Empty
+                let i2 = Interval.Empty
+                Interval.subtract i1 i2
+            let expectedEE = Interval.Empty
             Expect.equal actualEE expectedEE "Interval subtraction of Empty intervals is incorrect"
             )
 
         // Closed intervals include their minimal and maximal values. Therefore shared margins are intersections.
         testCase "isIntersection" (fun _ -> 
             let actual = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.create (-3.) (0.)
-                Intervals.isIntersection i1 i2
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.CreateClosed<float> (-3.,0.)
+                Interval.isIntersection i1 i2
             let expected = true
             Expect.equal actual expected "Intervals do intersect"
 
             let actualFalse = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.create (-infinity) (-6.)
-                Intervals.isIntersection i1 i2
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.CreateClosed<float> (-infinity,-6.)
+                Interval.isIntersection i1 i2
             let expectedFalse = false
             Expect.equal actual expected "Intervals do not intersect"
             
             let actualCE = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.Interval.Empty
-                Intervals.isIntersection i1 i2
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.Empty
+                Interval.isIntersection i1 i2
             let expectedCE = false
             Expect.equal actualCE expectedCE "Intervals do not intersect"
             
             let actualEC = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.create (-3.) (0.)
-                Intervals.isIntersection i1 i2
+                let i1 = Interval.Empty
+                let i2 = Interval.CreateClosed<float> (-3.,0.)
+                Interval.isIntersection i1 i2
             let expectedEC = false
             Expect.equal actualEC expectedEC "Empty intervals do not intersect"
             
             let actualEE = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.Interval.Empty
-                Intervals.isIntersection i1 i2
+                let i1 = Interval.Empty
+                let i2 = Interval.Empty
+                Interval.isIntersection i1 i2
             let expectedEE = true
             Expect.equal actualEE expectedEE "Empty intervals do intersect"
             
             let actualStr = 
-                let i1 = Intervals.create "a" "d"
-                let i2 = Intervals.create "de" "e"
-                Intervals.isIntersection i1 i2
+                let i1 = Interval.CreateClosed<string> ("a","d")
+                let i2 = Interval.CreateClosed<string> ("de","e")
+                Interval.isIntersection i1 i2
             let expectedStr = false
             Expect.equal actualStr expectedStr "String intervals do not intersect"
             
             let actualStrT = 
-                let i1 = Intervals.create "a" "d"
-                let i2 = Intervals.create "d" "e"
-                Intervals.isIntersection i1 i2
+                let i1 = Interval.CreateClosed<string> ("a","d")
+                let i2 = Interval.CreateClosed<string> ("d","e")
+                Interval.isIntersection i1 i2
             let expectedStrT = true
             Expect.equal actualStrT expectedStrT "String intervals do intersect"
             )
@@ -295,59 +295,59 @@ let intervalTests =
         // Closed intervals include their minimal and maximal values. Therefore shared margins are intersections.
         testCase "intersect" (fun _ -> 
             let actual = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.create (-3.) (0.)
-                Intervals.intersect i1 i2
-            let expected = Some (Intervals.create -3. 0.)
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.CreateClosed<float> (-3.,0.)
+                Interval.intersect i1 i2
+            let expected = Some (Interval.CreateClosed<float> (-3.,0.))
             Expect.equal actual expected "Interval intersect is calculated incorrectly"
 
             let actualFalse = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.create (-infinity) (-6.)
-                Intervals.intersect i1 i2
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.CreateClosed<float> (-infinity,-6.)
+                Interval.intersect i1 i2
             let expectedFalse = None
             Expect.equal actual expected "Interval intersect is calculated incorrectly"
 
             let actual2 = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.create (-infinity) (2.)
-                Intervals.intersect i1 i2
-            let expected2 = Some (Intervals.create -5. 2.)
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.CreateClosed<float> (-infinity,2.)
+                Interval.intersect i1 i2
+            let expected2 = Some (Interval.CreateClosed<float> (-5.,2.))
             Expect.equal actual2 expected2 "Intervals do intersect"
             
             let actualCE = 
-                let i1 = Intervals.create (-5.) (5.5)
-                let i2 = Intervals.Interval.Empty
-                Intervals.intersect i1 i2
+                let i1 = Interval.CreateClosed<float> (-5.,5.5)
+                let i2 = Interval.Empty
+                Interval.intersect i1 i2
             let expectedCE = None
             Expect.equal actualCE expectedCE "Intervals do not intersect"
             
             let actualEC = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.create (-3.) (0.)
-                Intervals.intersect i1 i2
+                let i1 = Interval.Empty
+                let i2 = Interval.CreateClosed<float> (-3.,0.)
+                Interval.intersect i1 i2
             let expectedEC = None
             Expect.equal actualEC expectedEC "Empty intervals do not intersect"
             
             let actualEE = 
-                let i1 = Intervals.Interval.Empty
-                let i2 = Intervals.Interval.Empty
-                Intervals.intersect i1 i2
-            let expectedEE = Some Intervals.Interval.Empty
+                let i1 = Interval.Empty
+                let i2 = Interval.Empty
+                Interval.intersect i1 i2
+            let expectedEE = Some Interval.Empty
             Expect.equal actualEE expectedEE "Empty intervals do intersect"
             
             let actualStr = 
-                let i1 = Intervals.create "a" "d"
-                let i2 = Intervals.create "de" "e"
-                Intervals.intersect i1 i2
+                let i1 = Interval.CreateClosed<string> ("a","d")
+                let i2 = Interval.CreateClosed<string> ("de","e")
+                Interval.intersect i1 i2
             let expectedStr = None
             Expect.equal actualStr expectedStr "String intervals do not intersect"
             
             let actualStrT = 
-                let i1 = Intervals.create "a" "d"
-                let i2 = Intervals.create "d" "e"
-                Intervals.intersect i1 i2
-            let expectedStrT = Some (Intervals.create "d" "d")
+                let i1 = Interval.CreateClosed<string> ("a","d")
+                let i2 = Interval.CreateClosed<string> ("d","e")
+                Interval.intersect i1 i2
+            let expectedStrT = Some (Interval.CreateClosed<string> ("d","d"))
             Expect.equal actualStrT expectedStrT "String intervals do intersect"
             )
 

--- a/tests/FSharp.Stats.Tests/Interval.fs
+++ b/tests/FSharp.Stats.Tests/Interval.fs
@@ -3,7 +3,7 @@
 open Expecto
 
 open FSharp.Stats
-open FSharp.Stats.Intervals
+open FSharp.Stats.Interval
 open TestExtensions
 
 [<Tests>]
@@ -13,46 +13,45 @@ let intervalTests =
     testList "Intervals" [
         
         testCase "create" (fun _ -> 
-            Expect.equal 1 1 "Instantiation of Intervals.Interval is incorrect"
 
-            let expected = Interval.ClosedInterval (-5.,5.)
-            let actual = Intervals.create -5. 5.
-            Expect.equal expected actual "Instantiation of Intervals.Interval is incorrect"
+            let expected = Interval.Closed (-5.,5.)
+            let actual = Interval.CreateClosed (-5.,5.)
+            Expect.equal expected actual "Instantiation of Interval.Closed is incorrect"
         
             //let expectedError() = Intervals.create 5. -5. |> ignore
             //Expect.throws expectedError "Interval maximum must be greater than minimum"
         )
         
         testCase "ofSeq" (fun _ -> 
-            let expected = Intervals.create -5. 5.
-            let actual = Intervals.ofSeq [3.;-0.;-5.;0.;0.;5.]
+            let expected = Interval.Closed (-5.,5.)
+            let actual = Interval.ofSeq [3.;-0.;-5.;0.;0.;5.]
             Expect.equal actual expected "Wrong interval was extracted from sequence"
 
-            let expectedInt = Intervals.create 5 5
-            let actualInt = Intervals.ofSeq [5;5;5;5;5;]
+            let expectedInt = Interval.Closed (-5,5)
+            let actualInt = Interval.ofSeq [5;5;5;5;5;]
             Expect.equal actualInt expectedInt "Wrong interval was extracted from sequence"
 
-            let nanCase() = Intervals.ofSeq [3.;nan;-0.;-5.;0.;0.;5.] |> ignore
+            let nanCase() = Interval.ofSeq [3.;nan;-0.;-5.;0.;0.;5.] |> ignore
             Expect.throws nanCase "collections containing nan should fail to return a valid interval"
         
-            let expectedInf = Intervals.create -5. infinity
-            let actualInf = Intervals.ofSeq [3.;infinity;-0.;-5.;infinity;0.;0.;5.]
+            let expectedInf = Interval.Closed (-5.,infinity)
+            let actualInf = Interval.ofSeq [3.;infinity;-0.;-5.;infinity;0.;0.;5.]
             Expect.equal actualInf expectedInf "infinity should be upper margin of interval"
         
-            let expectedInfNeg = Intervals.create -infinity 5.
-            let actualInfNeg = Intervals.ofSeq [3.;-infinity;-0.;-5.;0.;0.;-infinity;5.]
+            let expectedInfNeg = Interval.Closed (-infinity,5.)
+            let actualInfNeg = Interval.ofSeq [3.;-infinity;-0.;-5.;0.;0.;-infinity;5.]
             Expect.equal actualInfNeg expectedInfNeg "-infinity should be lower margin of interval"
         
-            let expectedInfs = Intervals.create -infinity infinity
-            let actualInfs = Intervals.ofSeq [3.;infinity;-0.;-5.;0.;0.;-infinity;5.]
+            let expectedInfs = Interval.Closed (-infinity,infinity)
+            let actualInfs = Interval.ofSeq [3.;infinity;-0.;-5.;0.;0.;-infinity;5.]
             Expect.equal actualInfs expectedInfs "-infinity and infinity should be interval margins"
         
-            let expectedEmpty = Intervals.Interval.Empty
-            let actualEmpty = Intervals.ofSeq []
+            let expectedEmpty = Interval.Empty
+            let actualEmpty = Interval.ofSeq []
             Expect.equal actualEmpty expectedEmpty "Interval should be empty"
             
-            let expectedStr = Intervals.create "aavbsd" "z"
-            let actualStr = Intervals.ofSeq ["asd";"bcd";"aavbsd";"z"]
+            let expectedStr = Interval.Closed ("aavbsd","z")
+            let actualStr = Interval.ofSeq ["asd";"bcd";"aavbsd";"z"]
             Expect.equal actualStr expectedStr "Interval of strings is incorrect"
             
             let expectedChar = Intervals.create 'f' 'r'

--- a/tests/FSharp.Stats.Tests/Signal.fs
+++ b/tests/FSharp.Stats.Tests/Signal.fs
@@ -37,8 +37,8 @@ let outlierTests =
 
 
     let compareIntervals a b (str:string) =
-        Expect.floatClose Accuracy.high (Intervals.getStart a) (Intervals.getStart b) str
-        Expect.floatClose Accuracy.high (Intervals.getEnd a) (Intervals.getEnd b) str
+        Expect.floatClose Accuracy.high (Interval.getStart a) (Interval.getStart b) str
+        Expect.floatClose Accuracy.high (Interval.getEnd a) (Interval.getEnd b) str
     
     testList "Signal.OutlierTests" [
         testList "Z-Score" [
@@ -59,11 +59,11 @@ let outlierTests =
                 TestExtensions.sequenceEqual Accuracy.high (zScoresOfSample ls) zLsSample "Z-Score of a sample was calculated incorrectly"
                 
             testCase "Population interval by Z-Score" <| fun()->
-                let populationInterval = Intervals.create -0.3635434661 3.432572444
+                let populationInterval = Interval.CreateClosed (-0.3635434661,3.432572444)
                 compareIntervals (populationIntervalByZScore -0.3 0.5 ls) populationInterval "Z-Score interval in a population was calculated incorrectly"
 
             testCase "Sample interval by Z-Score" <| fun()->
-                let sampleInterval = Intervals.create -0.4405465671 3.560910945
+                let sampleInterval = Interval.CreateClosed (-0.4405465671,3.560910945)
                 compareIntervals (sampleIntervalByZscore -0.3 0.5 ls) sampleInterval "Z-Score interval in a sample was calculated incorrectly"
         ]
 


### PR DESCRIPTION
Closes #286

**Please list the changes introduced in this PR**

- addition of open and half open intervals
- rename Intervals to Interval and shrink to `FSharp.Stats.Interval.createClosed` instead of `FSharp.Stats.Intervals.Interval.create`
- A check whether the interval minimum is lower than the interval maximum was **not** implemented because of the reasons discussed in #286. Briefly, in three dimensional space [1,2,3] < [2,1,3] returns true despite it beeing an invalid interval in the second dimension.

**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
