### PR TITLE
Returning `Interval` instead of tuples in distributions' Support members

### DIFF
--- a/src/FSharp.Stats/Distributions/Continuous/Beta.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Beta.fs
@@ -128,8 +128,8 @@ type Beta =
     /// Returns the support of the exponential distribution: [0.0, 1.0).
     static member Support alpha beta =
         Beta.CheckParam alpha beta
-        (0.0, 1.0)
-    
+        Interval.CreateRightOpen<float>(0.0, 1.0)
+
     /// A string representation of the distribution.
     static member ToString alpha beta =
         sprintf "Beta(α = %f, β = %f)" alpha beta

--- a/src/FSharp.Stats/Distributions/Continuous/Chi.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Chi.fs
@@ -75,7 +75,7 @@ type Chi =
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support dof =
         Chi.CheckParam dof
-        (0., System.Double.PositiveInfinity)
+        Interval.CreateRightOpen<float>(0.0, Double.PositiveInfinity)
 
 
     /// A string representation of the distribution.

--- a/src/FSharp.Stats/Distributions/Continuous/Exponential.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Exponential.fs
@@ -88,10 +88,13 @@ type Exponential =
 
 
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
+    [<Obsolete("Please use the function without the superfluous lambda parameter")>]
     static member Support lambda =
         Exponential.CheckParam lambda
-        Interval.CreateClosed<float> (0.0,System.Double.PositiveInfinity)
+        Interval.CreateRightOpen<float> (0.0, Double.PositiveInfinity)
 
+    static member Support () =
+        Interval.CreateRightOpen<float> (0.0, Double.PositiveInfinity)
 
     /// A string representation of the distribution.
     static member ToString lambda =

--- a/src/FSharp.Stats/Distributions/Continuous/F.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/F.fs
@@ -18,7 +18,7 @@ module internal F_Helpers =
             failwithf "Invalid definition of freedom %s \"%A\".%s"
                 name
                 dof1
-                "It must not be NaN and"
+                "It must not be NaN and it must be positive"
 
 /// F-distribution
 type F =

--- a/src/FSharp.Stats/Distributions/Continuous/F.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/F.fs
@@ -102,7 +102,7 @@ type F =
     /// Returns the support of the exponential distribution: (0., Positive Infinity).
     static member Support dof1 dof2 =
         F.CheckParam dof1 dof2
-        (0., System.Double.PositiveInfinity)
+        Interval.CreateRightOpen<float>(0., Double.PositiveInfinity)
      
     /// A string representation of the distribution.
     static member ToString dof1 dof2 =

--- a/src/FSharp.Stats/Distributions/Continuous/F.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/F.fs
@@ -11,14 +11,22 @@ open FSharp.Stats.Ops
 // wiki: "https://en.wikipedia.org/wiki/F-distribution"
 // ######
 
+/// F-distribution purely functional helper functions.
+module internal F_Helpers =
+ let assertValidDof name dof1 =
+        if isNan(dof1) || dof1 <= 0.0 then
+            failwithf "Invalid definition of freedom %s \"%A\".%s"
+                name
+                dof1
+                "It must not be NaN and"
 
 /// F-distribution
 type F =
-    
+
     // F-distribution helper functions.
-    static member CheckParam dof1 dof2 = 
-        if dof1 <= 0.0 || dof2 <= 0.0 || isNan(dof1) || isNan(dof2) then 
-            failwith "F-distribution should be parametrized by dof1 and dof2 > 0.0. and <> nan"
+    static member CheckParam (dof1) (dof2) : unit = 
+        dof1 |> F_Helpers.assertValidDof "dof1"
+        dof2 |> F_Helpers.assertValidDof "dof2"
 
     static member private CheckX x = 
         if x<0. || isNan(x) then 
@@ -99,11 +107,14 @@ type F =
             //Beta.lowerIncomplete (dof2 * 0.5) (dof1 * 0.5) u
             failwithf "InvCDF not implemented yet"
 
-    /// Returns the support of the exponential distribution: (0., Positive Infinity).
-    static member Support dof1 dof2 =
-        F.CheckParam dof1 dof2
-        Interval.CreateRightOpen<float>(0., Double.PositiveInfinity)
-     
+    /// Returns the support of the exponential distribution: if dof1 = 1 then (0., Positive Infinity) else [0., Positive Infinity).
+    static member Support dof1 =
+        dof1 |> F_Helpers.assertValidDof "dof1"
+        if dof1 = 1 then
+            Interval.CreateOpen<float>(0.0, Double.PositiveInfinity)
+        else
+            Interval.CreateRightOpen<float>(0.0, Double.PositiveInfinity)
+
     /// A string representation of the distribution.
     static member ToString dof1 dof2 =
         sprintf "FisherSnedecor(d1 = %f, d2 = %f" dof1 dof2

--- a/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
@@ -163,7 +163,7 @@ type Gamma =
     /// Returns the support of the gamma distribution: (0, Positive Infinity).
     static member Support alpha beta =
         Gamma.CheckParam alpha beta
-        Interval.CreateRightOpen<float>(0.0, Double.PositiveInfinity)
+        Interval.CreateOpen<float>(0.0, Double.PositiveInfinity)
 
     /// A string representation of the distribution.
     static member ToString alpha beta = 

--- a/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
@@ -160,7 +160,7 @@ type Gamma =
         let alpha,beta = Gamma.Fit(observations,maxIter,tol)
         Gamma.Init alpha beta 
 
-    /// Returns the support of the exponential distribution: (0, Positive Infinity).
+    /// Returns the support of the gamma distribution: (0, Positive Infinity).
     static member Support alpha beta =
         Gamma.CheckParam alpha beta
         Interval.CreateRightOpen<float>(0.0, Double.PositiveInfinity)

--- a/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
@@ -163,7 +163,7 @@ type Gamma =
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support alpha beta =
         Gamma.CheckParam alpha beta
-        (0.0, System.Double.PositiveInfinity)
+        Interval.CreateRightOpen<float>(0.0, Double.PositiveInfinity)
 
     /// A string representation of the distribution.
     static member ToString alpha beta = 

--- a/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
@@ -160,7 +160,7 @@ type Gamma =
         let alpha,beta = Gamma.Fit(observations,maxIter,tol)
         Gamma.Init alpha beta 
 
-    /// Returns the support of the exponential distribution: [0, Positive Infinity).
+    /// Returns the support of the exponential distribution: (0, Positive Infinity).
     static member Support alpha beta =
         Gamma.CheckParam alpha beta
         Interval.CreateRightOpen<float>(0.0, Double.PositiveInfinity)

--- a/src/FSharp.Stats/Distributions/Continuous/LogNormal.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/LogNormal.fs
@@ -72,10 +72,10 @@ type LogNormal =
         LogNormal.CheckParam mu sigma            
         Math.Exp (Normal.InvCDF mu sigma x)
  
-    /// Returns the support of the exponential distribution: [0, Positive Infinity).
+    /// Returns the support of the log normal distribution: (0, Positive Infinity).
     static member Support mu sigma =
         LogNormal.CheckParam mu sigma
-        Interval.CreateRightOpen<float>(0., Double.PositiveInfinity)
+        Interval.CreateOpen<float>(0., Double.PositiveInfinity)
 
     /// A string representation of the distribution.
     static member ToString mu sigma =

--- a/src/FSharp.Stats/Distributions/Continuous/LogNormal.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/LogNormal.fs
@@ -75,7 +75,7 @@ type LogNormal =
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support mu sigma =
         LogNormal.CheckParam mu sigma
-        (0., System.Double.PositiveInfinity)
+        Interval.CreateRightOpen<float>(0., Double.PositiveInfinity)
 
     /// A string representation of the distribution.
     static member ToString mu sigma =

--- a/src/FSharp.Stats/Distributions/Continuous/Normal.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Normal.fs
@@ -129,7 +129,7 @@ type Normal =
     /// Returns the support of the exponential distribution: [0, Positive Infinity).
     static member Support mu sigma =
         Normal.CheckParam mu sigma
-        (System.Double.NegativeInfinity, System.Double.PositiveInfinity)
+        Interval.CreateRightOpen<float>(Double.NegativeInfinity, Double.PositiveInfinity)
 
 
     /// A string representation of the distribution.

--- a/src/FSharp.Stats/Distributions/Continuous/StudentT.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/StudentT.fs
@@ -75,7 +75,7 @@ type StudentT =
     /// Returns the support of the exponential distribution: (Negative Infinity, Positive Infinity).
     static member Support mu tau dof =
         StudentT.CheckParam mu tau dof
-        (System.Double.NegativeInfinity, System.Double.PositiveInfinity)
+        Interval.CreateOpen<float>(Double.NegativeInfinity, Double.PositiveInfinity)
 
     /// A string representation of the distribution.
     static member ToString mu tau dof =

--- a/src/FSharp.Stats/Distributions/Discrete/NegativeBinomial.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/NegativeBinomial.fs
@@ -91,7 +91,7 @@ type NegativeBinomial_trials =
     /// <summary>Returns the support of the NegativeBinomial distribution: [0, max Int32).</summary>
     static member Support r p =
         NegativeBinomial_trials.CheckParam r p
-        (r, System.Int32.MaxValue)
+        Interval.CreateRightOpen<int>(r, Int32.MaxValue)
 
     /// A string representation of the distribution.
     static member ToString r p = 

--- a/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
+++ b/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
@@ -1038,7 +1038,7 @@ let FDistributionTests =
             let dof1            = 10.
             let dof2            = 25.
             let testcase    = 
-                Continuous.F.Support dof1 dof2
+                Continuous.F.Support dof1
             let r_value     = Interval.CreateRightOpen<float>(0., System.Double.PositiveInfinity)
 
             Expect.isTrue
@@ -1050,7 +1050,7 @@ let FDistributionTests =
             let dof1            = infinity
             let dof2            = infinity
             let testcase    = 
-                Continuous.F.Support dof1 dof2
+                Continuous.F.Support dof1
             let r_value     = Interval.CreateRightOpen<float>(0., Double.PositiveInfinity)
 
             Expect.isTrue
@@ -1058,6 +1058,53 @@ let FDistributionTests =
                 (testcase.GetEnd() = r_value.GetEnd()))
                 "Continuous.F.Support does not return the expected Tupel"
 
+        testCase "Continuous.F.Support_when_dof1_equals_1" <| fun() ->
+            // Arrange
+            let dof1 = 1.0
+
+            // Act
+            let result =
+                F.Support dof1
+
+            // Assert
+            match result with
+            | Interval.Open (start, end_) ->
+                Expect.equal
+                    start
+                    0.0
+                    "Expectation on \"Start\":"
+                Expect.equal
+                    end_
+                    Double.PositiveInfinity
+                    "Expectation on \"End\":"
+            | other ->
+                Expect.isTrue
+                    false
+                    (sprintf "Expected a fully open range (true), but it was %A (false)" other)
+
+        testCase "Continuous.F.Support_when_dof1_is_not_equal_to_1" <| fun() ->
+            // Arrange
+            let dof1 = 2.0
+
+            // Act
+            let result =
+                F.Support dof1
+
+            // Assert
+            match result with
+            | Interval.RightOpen (start, end_) ->
+                Expect.equal
+                    start
+                    0.0
+                    "Expectation on \"Start\":"
+                Expect.equal
+                    end_
+                    Double.PositiveInfinity
+                    "Expectation on \"End\":"
+            | other ->
+                Expect.isTrue
+                    false
+                    (sprintf "Expected a right open range (true), but it was %A (false)" other)
 
     ]
     

--- a/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
+++ b/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
@@ -1039,10 +1039,11 @@ let FDistributionTests =
             let dof2            = 25.
             let testcase    = 
                 Continuous.F.Support dof1 dof2
-            let r_value     = (0., System.Double.PositiveInfinity)
+            let r_value     = Interval.CreateRightOpen<float>(0., System.Double.PositiveInfinity)
 
             Expect.isTrue
-                ((fst testcase=fst r_value) && (snd testcase=snd r_value))
+                ((testcase.GetStart() = r_value.GetStart()) &&
+                ( testcase.GetEnd() =  r_value.GetEnd()))
                 "Continuous.F.Support does not return the expected Tupel"
         
         testCase "Continuous.F.Support_infinity" <| fun () ->
@@ -1050,10 +1051,11 @@ let FDistributionTests =
             let dof2            = infinity
             let testcase    = 
                 Continuous.F.Support dof1 dof2
-            let r_value     = (0., System.Double.PositiveInfinity)
+            let r_value     = Interval.CreateRightOpen<float>(0., Double.PositiveInfinity)
 
             Expect.isTrue
-                ((fst testcase=fst r_value) && (snd testcase=snd r_value))
+                ((testcase.GetStart() = r_value.GetStart()) &&
+                (testcase.GetEnd() = r_value.GetEnd()))
                 "Continuous.F.Support does not return the expected Tupel"
 
 


### PR DESCRIPTION
* Fixes #292 

This pull request introduces **breaking changes**.

Although these are just some small changes, they do represent breaking changes as the public contract of the `Support` members are changed.
The `Support`s of the exponential distribution and of the discrete negative binomial have also been fixed (were previously closed intervals, but they should have the right side "open").

**Check list**

 - [x] The project builds without problems on my machine

 - [x] Adapted unit tests regarding the added features
