### PR TITLE
Fix for `FSharp.Stats` Matrix Functionality**

### DIFF
--- a/src/FSharp.Stats/AlgTypes.fs
+++ b/src/FSharp.Stats/AlgTypes.fs
@@ -2099,7 +2099,7 @@ namespace FSharp.Stats
         /// </code>
         /// </example>
         let setColM (a:Matrix<_>) j (v:Vector<_>) = 
-            if a.NumCols = v.Length then
+            if a.NumRows = v.Length then
                 let l = v.Length-1
                 for i = 0 to l do
                     a.[i,j] <- v.[i]

--- a/tests/FSharp.Stats.Tests/Matrix.fs
+++ b/tests/FSharp.Stats.Tests/Matrix.fs
@@ -1133,10 +1133,10 @@ let floatImplementationDenseTests =
                     Expect.equal actual expected "Matrix.setCol did not return the correct vector"
 
                 testCase "Setting column out of col range using Matrix.setCol should fail" <| fun () ->
-                    Expect.throws (fun () -> Matrix.setRow testSquareMatrixA 1337 testVectorA |> ignore) "Setting column out of col range using Matrix.setCol did not fail although it should"
+                    Expect.throws (fun () -> Matrix.setCol testSquareMatrixA 1337 testVectorA |> ignore) "Setting column out of col range using Matrix.setCol did not fail although it should"
                 
                 testCase "Setting column with vector of wrong length using Matrix.setCol should fail" <| fun () ->
-                    Expect.throws (fun () -> Matrix.setRow testSquareMatrixA 1 testVector1LowerDiag |> ignore) "Setting row with vector of wrong length using Matrix.setRow did not fail although it should"
+                    Expect.throws (fun () -> Matrix.setCol testSquareMatrixA 1 testVector1LowerDiag |> ignore) "Setting row with vector of wrong length using Matrix.setRow did not fail although it should"
 
             ]
             testList "getCols" [

--- a/tests/FSharp.Stats.Tests/Matrix.fs
+++ b/tests/FSharp.Stats.Tests/Matrix.fs
@@ -1138,6 +1138,40 @@ let floatImplementationDenseTests =
                 testCase "Setting column with vector of wrong length using Matrix.setCol should fail" <| fun () ->
                     Expect.throws (fun () -> Matrix.setCol testSquareMatrixA 1 testVector1LowerDiag |> ignore) "Setting row with vector of wrong length using Matrix.setRow did not fail although it should"
 
+                testCase "Set Column non square" <| fun () ->
+
+                    let test2x3MatrixNonSquare : Matrix<float> =
+                        let values =
+                            Array2D.init
+                                2
+                                3
+                                (fun i j ->
+                                    0.
+                                )
+                        Matrix.DenseRepr
+                            (DenseMatrix<float>(Some (Instances.FloatNumerics :> INumeric<float>),values))
+
+                    Matrix.setCol test2x3MatrixNonSquare 0 ([1.;1.]|>Vector.ofList)
+
+                    let expected =
+                        let rows = 
+                            [|
+                                [|1.;0.;0.|]
+                                [|1.;0.;0.|]
+                            |]
+                        let values =
+                            Array2D.init
+                                2
+                                3
+                                (fun i j ->
+                                    rows.[i].[j]
+                                )
+                        Matrix.DenseRepr
+                            (DenseMatrix<float>(Some (Instances.FloatNumerics :> INumeric<float>),values))
+
+                    Expect.equal test2x3MatrixNonSquare expected "Matrix.setCol did not return the correct vector for non square Matrix"
+
+
             ]
             testList "getCols" [
                 


### PR DESCRIPTION
**Description:**

This pull request addresses the issues encountered in the `FSharp.Stats` library related to matrix manipulation, specifically in the `SpecializedGenericImpl.setColM` function and associated tests. 

**Changes Made:**

1. Corrected the validation check in the `setColM` function to properly utilize row counts instead of column counts. This ensures correct behavior, especially with non-square matrices.
   
2. Updated the tests in the `Matrix.fs` file to include scenarios for non-square matrices and utilize `Matrix.setCol` instead of `Matrix.setRow` for consistency.

**Testing:**

- Ran existing test suite to ensure that existing functionality is maintained.
- Added new test case to cover scenarios with non-square matrices and verified correct behavior of the `setCol` function.

**Related Issues:**
- Fixes #315
