### PR TITLE
remove AutoOpen on Seq, List and Array modules, define RequireQualifiedAccess on them.

### DIFF
--- a/src/FSharp.Stats/AlgTypes.fs
+++ b/src/FSharp.Stats/AlgTypes.fs
@@ -14,15 +14,12 @@
 //    RV   = row vector (dense)
 
 
-//namespace Microsoft.FSharp.Math // old namespace
 namespace FSharp.Stats
 
     #nowarn "60" // implementations in augmentations
     #nowarn "69" // implementations in augmentations
 
-    //open Microsoft.FSharp.Math
     open System
-    open System.Globalization
     open System.Collections
     open System.Collections.Generic
     open System.Diagnostics
@@ -2131,7 +2128,7 @@ namespace FSharp.Stats
 
 //----------------------------------------------------------------------------
 // type Matrix<'T> augmentation 
-//--------------------------------------------------------------------------*)
+//----------------------------------------------------------------------------
 // Interface implementation
 
     type Matrix<'T> with
@@ -2384,7 +2381,7 @@ namespace FSharp.Stats
 
 //----------------------------------------------------------------------------
 // type Vector<'T> augmentation
-//--------------------------------------------------------------------------*)
+//----------------------------------------------------------------------------
 // Interface implementation
 
     type Vector<'T> with
@@ -2458,7 +2455,7 @@ namespace FSharp.Stats
 
 //----------------------------------------------------------------------------
 // type RowVector<'T> augmentation
-//--------------------------------------------------------------------------*)
+//----------------------------------------------------------------------------
 
     type RowVector<'T> with
         static member ( +  )(a: RowVector<'T>,b) = SpecializedGenericImpl.addRV a b

--- a/src/FSharp.Stats/Algebra/LinearAlgebraServiceManaged.fs
+++ b/src/FSharp.Stats/Algebra/LinearAlgebraServiceManaged.fs
@@ -1,10 +1,7 @@
 // (c) Microsoft Corporation 2005-2009.
 
-//namespace Microsoft.FSharp.Math.LinearAlgebra // old namespace
 namespace FSharp.Stats.Algebra
 
-//open Microsoft.FSharp.Math
-//open Microsoft.FSharp.Math. Bindings.Internals.NativeUtilities
 open FSharp.Stats
 /// This module is for internal use only.
 module LinearAlgebraManaged = 

--- a/src/FSharp.Stats/Algebra/NativeArrayExtensions.fs
+++ b/src/FSharp.Stats/Algebra/NativeArrayExtensions.fs
@@ -11,7 +11,6 @@ namespace Microsoft.FSharp.NativeInterop
 open System
 open System.Runtime.InteropServices
 open Microsoft.FSharp.NativeInterop
-//open Microsoft.FSharp.Math
 open FSharp.Stats
 
 [<AutoOpen>]

--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -2,7 +2,6 @@
 
 
 /// Module to compute common statistical measure on array
-[<AutoOpen>]
 module Array =
 
 

--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -2,6 +2,7 @@
 
 
 /// Module to compute common statistical measure on array
+[<RequireQualifiedAccess>]
 module Array =
 
 

--- a/src/FSharp.Stats/Correlation.fs
+++ b/src/FSharp.Stats/Correlation.fs
@@ -38,6 +38,7 @@ module Correlation =
             |> (/) ((value - med) * weight)
 
     /// Contains correlation functions optimized for sequences
+    [<RequireQualifiedAccess>]
     module Seq = 
         /// <summary>Calculates the pearson correlation of two samples. Homoscedasticity must be assumed.</summary>
         /// <remarks></remarks>

--- a/src/FSharp.Stats/Correlation.fs
+++ b/src/FSharp.Stats/Correlation.fs
@@ -38,7 +38,6 @@ module Correlation =
             |> (/) ((value - med) * weight)
 
     /// Contains correlation functions optimized for sequences
-    [<AutoOpen>]
     module Seq = 
         /// <summary>Calculates the pearson correlation of two samples. Homoscedasticity must be assumed.</summary>
         /// <remarks></remarks>
@@ -488,7 +487,7 @@ module Correlation =
         /// </code>
         /// </example>
         let autoCorrelation lag v1 = 
-            correlationOf pearson lag v1 v1
+            correlationOf Seq.pearson lag v1 v1
 
         /// <summary>computes the sample auto corvariance of a signal at a given lag.</summary>
         /// <remarks></remarks>
@@ -513,7 +512,7 @@ module Correlation =
         /// </code>
         /// </example>
         let normalizedXCorr lag v1 v2 = 
-            correlationOf pearson lag v1 v2
+            correlationOf Seq.pearson lag v1 v2
 
         /// <summary>computes the unnormalized (using only the dot product) cross-correlation of signals v1 and v2 at a given lag.</summary>
         /// <remarks></remarks>

--- a/src/FSharp.Stats/DistanceMetrics.fs
+++ b/src/FSharp.Stats/DistanceMetrics.fs
@@ -193,7 +193,8 @@ module DistanceMetrics =
                     Some (dist ** (1.0 / p))
                 else
                     Some dist
- 
+    
+    [<RequireQualifiedAccess>]    
     module Array =
         
         /// <summary>Calculates Hamming distance of two coordinate arrays</summary>

--- a/src/FSharp.Stats/INumeric.fs
+++ b/src/FSharp.Stats/INumeric.fs
@@ -1,9 +1,7 @@
 // (c) Microsoft Corporation 2005-2009.  
 
-//namespace Microsoft.FSharp.Math // old namespace
 namespace FSharp.Stats
 
-//open Microsoft.FSharp.Math
 open System
 open System.Numerics
 open System.Globalization

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -2,7 +2,6 @@
 
 
 /// Module to compute common statistical measure on list
-[<AutoOpen>]
 module List =
     let range (items:list<_>) =        
         let rec loop l (minimum) (maximum) =

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -2,6 +2,7 @@
 
 
 /// Module to compute common statistical measure on list
+[<RequireQualifiedAccess>]    
 module List =
     let range (items:list<_>) =        
         let rec loop l (minimum) (maximum) =

--- a/src/FSharp.Stats/ML/DistanceMetrics.fs
+++ b/src/FSharp.Stats/ML/DistanceMetrics.fs
@@ -55,7 +55,8 @@ module DistanceMetrics =
         /// </example>
         let cityblockNaN (v1:Vector<float>) (v2:Vector<float>) = 
             DistanceMetrics.Vector.cityblockNaN v1 v2
- 
+    
+    [<RequireQualifiedAccess>]
     module Array = 
         
         [<Obsolete("Use FSharp.Stats.DistanceMetrics.Array.euclidean instead")>]

--- a/src/FSharp.Stats/ML/Unsupervised/KNN.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/KNN.fs
@@ -6,6 +6,7 @@ module KNN =
 
     open FSharp.Stats.DistanceMetrics
 
+    [<RequireQualifiedAccess>]    
     module Array =
 
         /// <summary>
@@ -46,7 +47,8 @@ module KNN =
                     |> fst
 
                 Some label
-        
+
+    [<RequireQualifiedAccess>]
     module Seq =
 
         /// <summary>

--- a/src/FSharp.Stats/Matrix.fs
+++ b/src/FSharp.Stats/Matrix.fs
@@ -1,10 +1,8 @@
-//namespace Microsoft.FSharp.Math // old namespace
 namespace FSharp.Stats
 
 #nowarn "60" // implementations in augmentations
 #nowarn "69" // implementations in augmentations
 
-//open Microsoft.FSharp.Math
 open System
 open System.Globalization
 open System.Collections

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -2,6 +2,7 @@ namespace FSharp.Stats
 
 
 /// Module to compute common statistical measure
+[<RequireQualifiedAccess>]
 module Seq = 
 
     module OpsS = SpecializedGenericImpl

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -2,7 +2,6 @@ namespace FSharp.Stats
 
 
 /// Module to compute common statistical measure
-[<AutoOpen>]
 module Seq = 
 
     module OpsS = SpecializedGenericImpl

--- a/src/FSharp.Stats/Signal/Outliers.fs
+++ b/src/FSharp.Stats/Signal/Outliers.fs
@@ -44,7 +44,7 @@ module Outliers =
     /// </example>
     let zScoresOfPopulation (ls:list<float>) =
         let m = List.mean ls
-        let s = stDevPopulation(ls)
+        let s = Seq.stDevPopulation(ls)
         [for x in ls -> zScore x m s]
 
 
@@ -60,7 +60,7 @@ module Outliers =
     /// </example>
     let populationIntervalByZScore (minZ:float) (maxZ:float) (ls:list<float>) =
         let m = List.mean ls
-        let s = stDevPopulation(ls)
+        let s = Seq.stDevPopulation(ls)
         Interval.CreateClosed<float> ((minZ * s + m),(maxZ * s + m))
     
     /// <summary>Returns a list of Z scores of a sample</summary>
@@ -73,7 +73,7 @@ module Outliers =
     /// </example>
     let zScoresOfSample (ls:list<float>) =
         let m = List.mean ls
-        let s = stDev(ls)
+        let s = Seq.stDev(ls)
         [for x in ls -> zScore x m s]
 
     /// <summary>Returns a sample interval according to desired max and min Z Score values    </summary>
@@ -88,7 +88,7 @@ module Outliers =
     /// </example>
     let sampleIntervalByZscore (minZ:float) (maxZ:float) (ls:list<float>) =
         let m = List.mean ls
-        let s = stDev(ls)
+        let s = Seq.stDev(ls)
         Interval.CreateClosed<float> ((minZ * s + m),(maxZ * s + m))
 
     ///Returns Mahalanobi's distance for an individual observation in a matrix.

--- a/src/FSharp.Stats/Vector.fs
+++ b/src/FSharp.Stats/Vector.fs
@@ -1,20 +1,14 @@
-//namespace Microsoft.FSharp.Math // old namespace
 namespace FSharp.Stats
 
 #nowarn "60" // implementations in augmentations
 #nowarn "69" // implementations in augmentations
 
-//open Microsoft.FSharp.Math
 open System
-open System.Globalization
 open System.Collections
-open System.Collections.Generic
-open System.Diagnostics
-
 
 //----------------------------------------------------------------------------
 // module Vector
-//--------------------------------------------------------------------------*)
+//----------------------------------------------------------------------------
       
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 //Basic vector operations
@@ -24,22 +18,14 @@ module Vector =
         
         module OpsS = SpecializedGenericImpl
         /// <summary>Returns the value of the vector a at the given index i</summary>
-        /// <remarks></remarks>
-        /// <param name="vector"></param>
-        /// <returns></returns>
-        /// <example>
-        /// <code>
-        /// </code>
-        /// </example>
+        /// <param name="vector">vector to get value for</param>
+        /// <param name="index">index in the vector to get value for</param>
+        /// <returns>the value at index</returns>
         let get (vector:Vector<'T>) index  = vector.[index]
-        /// <summary>Sets the value x to the vector a at the given index i</summary>
-        /// <remarks></remarks>
-        /// <param name="vector"></param>
-        /// <returns></returns>
-        /// <example>
-        /// <code>
-        /// </code>
-        /// </example>
+        /// <summary>Sets the value to the vector a at the given index</summary>
+        /// <param name="vector">vector to set value for</param>
+        /// <param name="index">index in the vector to set value for</param>
+        /// <param name="value">value to set in the vector</param>
         let set (vector:Vector<'T>) index value  = vector.[index] <- value
         /// <summary>Returns length of vector v</summary>
         /// <remarks></remarks>
@@ -664,7 +650,7 @@ module Vector =
                 let current = items.[index]
                 loop (index+1) (min current minimum) (max current maximum)
             else
-                Interval.CreateClosed<'a> (minimum,maximum)
+                Interval.CreateClosed<_> (minimum,maximum)
         //Init by fist value
         if items.Length > 1 then
             loop 1 items.[0] items.[0] 
@@ -870,8 +856,8 @@ module VectorExtension =
         /// Creates an vector with values between a given interval
         /// </summary>
         /// <param name="start">start value (is included)</param>
-        /// <param name="stop">end value (by default is included )</param>
-        /// <param name="Num">sets the number of elements in the vector. If not set, stepsize = 1.</param>
+        /// <param name="stop">end value (by default is included)</param>
+        /// <param name="num">sets the number of elements in the vector. If not set, stepsize = 1.</param>
         /// <param name="IncludeEndpoint">If false, the vector does not contain the stop value</param>
         static member linspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : vector = 
         
@@ -884,7 +870,7 @@ module VectorExtension =
         /// </summary>
         /// <param name="start">start value (is included)</param>
         /// <param name="stop">end value (by default is included)</param>
-        /// <param name="Num">sets the number of elements in the vector. Defaults to 50.</param>
+        /// <param name="num">sets the number of elements in the vector. Defaults to 50.</param>
         /// <param name="IncludeEndpoint">If false, the vector does not contain the stop value. Defaults to true.</param>
         static member geomspace(start:float,stop:float,num:int,?IncludeEndpoint:bool) : vector = 
             let includeEndpoint = defaultArg IncludeEndpoint true

--- a/tests/FSharp.Stats.Tests/DistanceMetrics.fs
+++ b/tests/FSharp.Stats.Tests/DistanceMetrics.fs
@@ -1,47 +1,45 @@
 ﻿module DistanceMetricsTests
 open Expecto
 open FSharp.Stats
-open FSharp.Stats.DistanceMetrics
 open FSharp.Stats.DistanceMetrics.Vector
-open FSharp.Stats.DistanceMetrics.Array
-
+open FSharp.Stats.DistanceMetrics
 [<Tests>]
 let hammingfunctiontests =
     testList "DistanceMetrics.hamming" [
         testCase "hamming" <| fun () ->
             let seq1 = seq {0;0;0;0}
             let seq2 = seq {1;1;1;1}
-            let distance = DistanceMetrics.hamming seq1 seq2 
+            let distance = hamming seq1 seq2 
             Expect.equal distance 4 "Should be equal"
         testCase "hamming0" <| fun () ->
             let seq1 = seq {0.0;0.0;0.0;0.0}
             let seq2 = seq {0.0;0.0;0.0;0.0}
-            let distance = DistanceMetrics.hamming seq1 seq2 
+            let distance = hamming seq1 seq2 
             Expect.equal distance 0 "Should be equal"
         testCase "hamminginfinity" <| fun () ->
             let seq1 = seq {infinity;-infinity}
             let seq2 = seq {infinity;-infinity}
-            let distance = DistanceMetrics.hamming seq1 seq2 
+            let distance = hamming seq1 seq2 
             Expect.equal distance 0 "Should be equal"
         testCase "hammingcharacters" <| fun () ->
             let seq1 = seq {"a";"b";"c"}
             let seq2 = seq {"a";"b";"c"}
-            let distance = DistanceMetrics.hamming seq1 seq2 
+            let distance = hamming seq1 seq2 
             Expect.equal distance 0 "Should be equal"
         testCase "hamminglists" <| fun () ->
             let l1 = [1.0;2.0]
             let l2 = [1.0;3.0]
-            let distance = DistanceMetrics.hamming l1 l2 
+            let distance = hamming l1 l2 
             Expect.equal distance 1 "Should be equal"
         testCase "hammingstrings" <| fun () ->
             let s1 = "karolin"
             let s2 = "kathrin"
-            let distance = DistanceMetrics.hamming s1 s2 
+            let distance = hamming s1 s2 
             Expect.equal distance 3 "Should be equal"
         testCase "hammingexception" <| fun () ->
             let seq1 = seq {0}
             let seq2 = seq {1;1}
-            Expect.throws (fun () -> DistanceMetrics.hamming seq1 seq2 |> ignore) "Should throw"
+            Expect.throws (fun () -> hamming seq1 seq2 |> ignore) "Should throw"
     ]
     
 [<Tests>]
@@ -50,22 +48,22 @@ let hammingvecfunctiontests =
         testCase "hamming" <| fun () ->
             let v1 = vector [0;0;0;0]
             let v2 = vector [1;1;1;1]
-            let distance = DistanceMetrics.Vector.hamming v1 v2 
+            let distance = Vector.hamming v1 v2 
             Expect.equal distance 4 "Should be equal"
         testCase "hamming0" <| fun () ->
             let v1 = vector [0.0;0.0;0.0;0.0]
             let v2 = vector [0.0;0.0;0.0;0.0]
-            let distance = DistanceMetrics.Vector.hamming v1 v2
+            let distance = Vector.hamming v1 v2
             Expect.equal distance 0 "Should be equal"
         testCase "hamminginfinity" <| fun () ->
             let v1 = vector [infinity;-infinity]
             let v2 = vector [infinity;-infinity]
-            let distance = DistanceMetrics.Vector.hamming v1 v2 
+            let distance = Vector.hamming v1 v2 
             Expect.equal distance 0 "Should be equal"
         testCase "hammingexception" <| fun () ->
             let v1 = vector [0]
             let v2 = vector [1;1]
-            Expect.throws (fun () -> DistanceMetrics.Vector.hamming v1 v2 |> ignore) "Should throw"
+            Expect.throws (fun () -> Vector.hamming v1 v2 |> ignore) "Should throw"
     ]
     
 [<Tests>]
@@ -74,27 +72,27 @@ let hammingarrayfunctiontests =
         testCase "hamming" <| fun () ->
             let a1 = [|0;0;0;0|]
             let a2 = [|1;1;1;1|]
-            let distance = DistanceMetrics.Array.hamming a1 a2 
+            let distance = Array.hamming a1 a2 
             Expect.equal distance 4 "Should be equal"
         testCase "hamming0" <| fun () ->
             let a1 = [|0.0;0.0;0.0;0.0|]
             let a2 = [|0.0;0.0;0.0;0.0|]
-            let distance = DistanceMetrics.Array.hamming a1 a2 
+            let distance = Array.hamming a1 a2 
             Expect.equal distance 0 "Should be equal"
         testCase "hamminginfinity" <| fun () ->
             let a1 = [|infinity;-infinity|]
             let a2 = [|infinity;-infinity|]
-            let distance = DistanceMetrics.Array.hamming a1 a2 
+            let distance = Array.hamming a1 a2 
             Expect.equal distance 0 "Should be equal"
         testCase "hammingcharacters" <| fun () ->
             let a1 = [|"a";"b";"c"|]
             let a2 = [|"a";"b";"c"|]
-            let distance = DistanceMetrics.Array.hamming a1 a2 
+            let distance = Array.hamming a1 a2 
             Expect.equal distance 0 "Should be equal"
         testCase "hammingexception" <| fun () ->
             let a1 = [|0|]
             let a2 = [|1;1|]
-            Expect.throws (fun () -> DistanceMetrics.Array.hamming a1 a2 |> ignore) "Should throw"
+            Expect.throws (fun () -> Array.hamming a1 a2 |> ignore) "Should throw"
     ]
 
 [<Tests>]
@@ -103,64 +101,64 @@ let euclidianseqfunctiontests =
         testCase "euclidian" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 10000.0}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclidean seq1 seq2 
+            let distance = euclidean seq1 seq2 
             Expect.floatClose Accuracy.high distance 9999.0034 "Should be equal"
         testCase "euclidianinf" <| fun () ->
             let seq1 = seq {0.001; -2.0; -infinity; infinity}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclidean seq1 seq2 
+            let distance = euclidean seq1 seq2 
             Expect.equal distance infinity "Should be equal"
         testCase "euclidian0" <| fun () ->
             let seq1 = seq {0.0; 0.0; 0.0; 0.0}
             let seq2 = seq {0.0;0.0;0.0;0.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclidean seq1 seq2 
+            let distance = euclidean seq1 seq2 
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "euclidiannan" <| fun () ->
             let seq1 = seq {00.001; -2.0; 0.0; nan}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclidean seq1 seq2 
+            let distance = euclidean seq1 seq2 
             Expect.isTrue (nan.Equals(distance)) "Distance should be NaN"
 
         testCase "euclidianNaN" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 10000.0}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaN seq1 seq2 
+            let distance = euclideanNaN seq1 seq2 
             Expect.floatClose Accuracy.high distance 9999.0034 "Should be equal"
         testCase "euclidianNaNinf" <| fun () ->
             let seq1 = seq {0.001; -2.0; -infinity; infinity}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaN seq1 seq2 
+            let distance = euclideanNaN seq1 seq2 
             Expect.equal distance infinity "Should be equal"
         testCase "euclidianNaN0" <| fun () ->
             let seq1 = seq {0.0; 0.0; 0.0; 0.0}
             let seq2 = seq {0.0;0.0;0.0;0.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaN seq1 seq2 
+            let distance = euclideanNaN seq1 seq2 
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "euclidianNaNnan" <| fun () ->
             let seq1 = seq {00.001; -2.0; 0.0; nan}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaN seq1 seq2 
+            let distance = euclideanNaN seq1 seq2 
             Expect.floatClose Accuracy.high distance 8.245968773 "Should be equal"
 
         testCase "euclidianNaNsqrt" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 10000.0}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaNSquared seq1 seq2 
+            let distance = euclideanNaNSquared seq1 seq2 
             Expect.floatClose Accuracy.high distance 99980069 "Should be equal"
         testCase "euclidianNaNsqrtinf" <| fun () ->
             let seq1 = seq {0.001; -2.0; -infinity; infinity}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaNSquared seq1 seq2 
+            let distance = euclideanNaNSquared seq1 seq2 
             Expect.equal distance infinity "Should be equal"
         testCase "euclidianNaNsqrt0" <| fun () ->
             let seq1 = seq {0.0; 0.0; 0.0; 0.0}
             let seq2 = seq {0.0;0.0;0.0;0.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaNSquared seq1 seq2 
+            let distance = euclideanNaNSquared seq1 seq2 
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "euclidianNaNsqrtnan" <| fun () ->
             let seq1 = seq {00.001; -2.0; 0.0; nan}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.euclideanNaNSquared seq1 seq2 
+            let distance = euclideanNaNSquared seq1 seq2 
             Expect.floatClose Accuracy.high distance 67.996001 "Should be equal"
     ]
 
@@ -172,22 +170,22 @@ let euclidianvecfunctiontests =
         testCase "euclidian" <| fun () -> 
             let v1 = vector [0.001; -2.0; 0.0; 10000.0]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclidean v1 v2
+            let distance = Vector.euclidean v1 v2
             Expect.floatClose Accuracy.high distance 9999.0034 "Should be equal"
         testCase "euclidianinf" <| fun () ->
             let v1 = vector [0.001; -2.0; -infinity; infinity]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclidean v1 v2 
+            let distance = Vector.euclidean v1 v2 
             Expect.equal distance infinity "Should be equal"
         testCase "euclidian0" <| fun () ->
             let v1 = vector [0.0; 0.0; 0.0; 0.0]
             let v2 = vector [0.0;0.0;0.0;0.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclidean v1 v2 
+            let distance = Vector.euclidean v1 v2 
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "euclidiannan" <| fun () ->
             let v1 = vector [00.001; -2.0; 0.0; nan]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclidean v1 v2 
+            let distance = Vector.euclidean v1 v2 
             Expect.isTrue (nan.Equals(distance)) "Distance should be NaN"
 
         testCase "euclidiansqrt" <| fun () -> 
@@ -214,22 +212,22 @@ let euclidianvecfunctiontests =
         testCase "euclidianNaN" <| fun () -> 
             let v1 = vector [0.001; -2.0; 0.0; 10000.0]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclideanNaN v1 v2
+            let distance = Vector.euclideanNaN v1 v2
             Expect.floatClose Accuracy.high distance 9999.0034 "Should be equal"
         testCase "euclidianNaNinf" <| fun () ->
             let v1 = vector [0.001; -2.0; -infinity; infinity]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclideanNaN v1 v2
+            let distance = Vector.euclideanNaN v1 v2
             Expect.equal distance infinity "Should be equal"
         testCase "euclidianNaN0" <| fun () ->
             let v1 = vector [0.0; 0.0; 0.0; 0.0]
             let v2 = vector [0.0;0.0;0.0;0.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclideanNaN v1 v2
+            let distance = Vector.euclideanNaN v1 v2
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "euclidianNaNnan" <| fun () ->
             let v1 = vector [00.001; -2.0; 0.0; nan]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.euclideanNaN v1 v2
+            let distance = Vector.euclideanNaN v1 v2
             Expect.floatClose Accuracy.high distance 8.245968773 "Should be equal"
 
     ]
@@ -308,43 +306,43 @@ let cityblockseqfunctiontests =
         testCase "cityblock" <| fun () -> 
             let seq1 = seq {0.001; -2.0; 0.0; 10000.0}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblock seq1 seq2
+            let distance = cityblock seq1 seq2
             Expect.floatClose Accuracy.high distance 10008.999 "Should be equal"
         testCase "cityblockinf" <| fun () ->
             let seq1 = seq {0.001; -2.0; -infinity; infinity}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblock seq1 seq2
+            let distance = cityblock seq1 seq2
             Expect.equal distance infinity "Should be equal"
         testCase "cityblock0" <| fun () ->
             let seq1 = seq {0.0; 0.0; 0.0; 0.0}
             let seq2 = seq {0.0;0.0;0.0;0.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblock seq1 seq2
+            let distance = cityblock seq1 seq2
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "cityblocknan" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; nan}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblock seq1 seq2
+            let distance = cityblock seq1 seq2
             Expect.isTrue (nan.Equals(distance)) "Distance should be NaN"
 
         testCase "cityblockNaN" <| fun () -> 
             let seq1 = seq {0.001; -2.0; 0.0; 10000.0}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblockNaN seq1 seq2
+            let distance = cityblockNaN seq1 seq2
             Expect.floatClose Accuracy.high distance 10008.999 "Should be equal"
         testCase "cityblockNaNinf" <| fun () ->
             let seq1 = seq {0.001; -2.0; -infinity; infinity}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblockNaN seq1 seq2
+            let distance = cityblockNaN seq1 seq2
             Expect.equal distance infinity "Should be equal"
         testCase "cityblockNaN0" <| fun () ->
             let seq1 = seq {0.0; 0.0; 0.0; 0.0}
             let seq2 = seq {0.0;0.0;0.0;0.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblockNaN seq1 seq2
+            let distance = cityblockNaN seq1 seq2
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "cityblockNaNnan" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; nan}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = FSharp.Stats.DistanceMetrics.cityblockNaN seq1 seq2
+            let distance = cityblockNaN seq1 seq2
             Expect.floatClose Accuracy.high distance 9.999 "Should be equal"
     ]
 
@@ -354,43 +352,43 @@ let cityblockvectorfunctiontests =
         testCase "cityblock" <| fun () -> 
             let v1 = vector [0.001; -2.0; 0.0; 10000.0]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblock v1 v2
+            let distance = Vector.cityblock v1 v2
             Expect.floatClose Accuracy.high distance 10008.999 "Should be equal"
         testCase "cityblockinf" <| fun () ->
             let v1 = vector [0.001; -2.0; -infinity; infinity]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblock v1 v2 
+            let distance = Vector.cityblock v1 v2 
             Expect.equal distance infinity "Should be equal"
         testCase "cityblock0" <| fun () ->
             let v1 = vector [0.0; 0.0; 0.0; 0.0]
             let v2 = vector [0.0;0.0;0.0;0.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblock v1 v2 
+            let distance = Vector.cityblock v1 v2 
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "cityblocknan" <| fun () ->
             let v1 = vector [00.001; -2.0; 0.0; nan]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblock v1 v2 
+            let distance = Vector.cityblock v1 v2 
             Expect.isTrue (nan.Equals(distance)) "Distance should be NaN"
 
         testCase "cityblockNaN" <| fun () -> 
             let v1 = vector [0.001; -2.0; 0.0; 10000.0]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblockNaN v1 v2
+            let distance = Vector.cityblockNaN v1 v2
             Expect.floatClose Accuracy.high distance 10008.999 "Should be equal"
         testCase "cityblockNaNinf" <| fun () ->
             let v1 = vector [0.001; -2.0; -infinity; infinity]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblockNaN  v1 v2 
+            let distance = Vector.cityblockNaN  v1 v2 
             Expect.equal distance infinity "Should be equal"
         testCase "cityblockNaN0" <| fun () ->
             let v1 = vector [0.0; 0.0; 0.0; 0.0]
             let v2 = vector [0.0;0.0;0.0;0.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblockNaN  v1 v2 
+            let distance = Vector.cityblockNaN  v1 v2 
             Expect.floatClose Accuracy.high distance 0.0 "Should be equal"
         testCase "cityblockNaNnan" <| fun () ->
             let v1 = vector [00.001; -2.0; 0.0; nan]
             let v2 = vector [2.0;-10.0;0.0;1.0]
-            let distance = FSharp.Stats.DistanceMetrics.Vector.cityblockNaN  v1 v2 
+            let distance = Vector.cityblockNaN  v1 v2 
             Expect.floatClose Accuracy.high distance 9.999 "Should be equal"
     ]
 
@@ -470,69 +468,69 @@ let minkowskiseqfunctiontests =
         testCase "minkowskiNoValue" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 10_000.0}
             let seq2 = seq {2.0; -10.0; 0.0; 1.0}
-            let distance = DistanceMetrics.minkowski seq1 seq2 0.0
+            let distance = minkowski seq1 seq2 0.0
             Expect.isTrue distance.IsNone "No Value"        
 
         testCase "minkowskiVsEuclidian" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 10_000.0}            
             let seq2 = seq {2.0; -10.0; 0.0; 1.0} 
-            let distance = DistanceMetrics.minkowski seq1 seq2 2.0
+            let distance = minkowski seq1 seq2 2.0
             Expect.isTrue distance.IsSome "Has Value"
             Expect.floatClose Accuracy.high distance.Value 9999.0034 "Should be equal"
               
         testCase "minkowskiOrder3" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 1.5}            
             let seq2 = seq {2.0; -10.0; 0.5; 1.0} 
-            let distance = DistanceMetrics.minkowski seq1 seq2 3.0
+            let distance = minkowski seq1 seq2 3.0
             Expect.isTrue distance.IsSome "Has Value"
             Expect.floatClose Accuracy.high distance.Value 8.04267819780 "Should be equal"
               
         testCase "minkowskiOrder5" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 1.5}            
             let seq2 = seq {2.0; -10.0; 0.5; 1.0} 
-            let distance = DistanceMetrics.minkowski seq1 seq2 5.0
+            let distance = minkowski seq1 seq2 5.0
             Expect.isTrue distance.IsSome "Has Value"
             Expect.floatClose Accuracy.high distance.Value 8.00156104008 "Should be equal"
         
         testCase "minkowskiOrder0.5" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 1.5}            
             let seq2 = seq {2.0; -10.0; 0.5; 1.0} 
-            let distance = DistanceMetrics.minkowski seq1 seq2 0.5
+            let distance = minkowski seq1 seq2 0.5
             Expect.isTrue distance.IsSome "Has Value"
             Expect.floatClose Accuracy.high distance.Value 5.6565006518965619264 "Should be equal"
         
         testCase "minkowskiLengths" <| fun () ->        
             let seq1 = seq {0.001; -2.0; 0.0; 1.5}            
             let seq2 = seq {2.0; -10.0; 0.5; 1.0; 1_000.0; 6.0; 7.} // last elements are ignored
-            let distance = DistanceMetrics.minkowski seq1 seq2 5.0
+            let distance = minkowski seq1 seq2 5.0
             Expect.isTrue distance.IsSome "Has Value"
             Expect.floatClose Accuracy.high distance.Value 8.00156104008 "Should be equal"
 
         testCase "minkowskiWithNaN" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; nan}      
             let seq2 = seq {2.0; -10.0; 0.0; 1.0; 0.0} 
-            let distance = DistanceMetrics.minkowski seq1 seq2 3.0
+            let distance = minkowski seq1 seq2 3.0
             Expect.isTrue distance.IsSome "Has Value"
             Expect.isTrue (nan.Equals(distance.Value)) "Distance should be NaN"
 
         testCase "minkowskiNaN" <| fun () ->
             let seq1 = seq {0.001; -2.0; 0.0; 10_000.0; nan}   
             let seq2 = seq {2.0; -10.0; 0.0; 1.0; 0.0} 
-            let distance = DistanceMetrics.minkowskiNaN seq1 seq2 2.0
+            let distance = minkowskiNaN seq1 seq2 2.0
             Expect.isTrue distance.IsSome "Has Value"
             Expect.floatClose Accuracy.high distance.Value 9999.0034 "Should be equal"
                 
         testCase "minkowskiInf" <| fun () ->
             let seq1 = seq {0.001; -2.0; -infinity; infinity}
             let seq2 = seq {2.0;-10.0;0.0;1.0}
-            let distance = DistanceMetrics.minkowski seq1 seq2 2.0
+            let distance = minkowski seq1 seq2 2.0
             Expect.isTrue distance.IsSome "Has Value"
             Expect.equal distance.Value infinity "Should be equal"
                 
         testCase "minkowski0" <| fun () ->
             let seq1 = seq {0.0; 0.0; 0.0; 0.0}
             let seq2 = seq {0.0; 0.0; 0.0; 0.0}
-            let distance = DistanceMetrics.minkowski seq1 seq2 2.0
+            let distance = minkowski seq1 seq2 2.0
             Expect.isTrue distance.IsSome "Has Value"         
             Expect.floatClose Accuracy.high distance.Value 0.0 "Should be equal"        
     ]

--- a/tests/FSharp.Stats.Tests/ML.fs
+++ b/tests/FSharp.Stats.Tests/ML.fs
@@ -389,9 +389,6 @@ module hClust =
 
 module KNN =
     open FSharp.Stats.ML.Unsupervised
-    open FSharp.Stats.ML.Unsupervised.KNN.Array
-    open FSharp.Stats.ML.Unsupervised.KNN.Seq
-    open FSharp.Stats.Vector
 
     [<Tests>]
     let knnTests = 

--- a/tests/FSharp.Stats.Tests/Signal.fs
+++ b/tests/FSharp.Stats.Tests/Signal.fs
@@ -12,7 +12,7 @@ open TestExtensions
 [<Tests>]
 let outlierTests =
     let ls = [-1.4; -1.4; -1.3; -7.9; 9.4; -1.5; 5.0; 7.0; 1.1; 1.6]
-    let m = mean ls //1.06
+    let m = List.mean ls //1.06
     
     let dataRow =
         [
@@ -44,11 +44,11 @@ let outlierTests =
     testList "Signal.OutlierTests" [
         testList "Z-Score" [
             testCase "Z-Score in a population" <| fun() ->
-                let s = stDevPopulation(ls) //4.745144887
+                let s = Seq.stDevPopulation(ls) //4.745144887
                 Expect.floatClose Accuracy.high (zScore -1.4 m s) -0.5184246337 "Z-Score in a population was calculated incorrectly"
 
             testCase "Z-Score in a sample" <| fun()->
-                let sSample = stDev(ls)
+                let sSample = Seq.stDev(ls)
                 Expect.floatClose Accuracy.high (zScore -1.4 m sSample) -0.4918207913 "Z-Score in a sample was calculated incorrectly"
                 
             testCase "Z-Scores of a population" <| fun()->


### PR DESCRIPTION
Closes #312

**Description**

There are few shenanigans with `FSharp.Stats.DistanceMetrics.Vector` and `FSharp.Stats.DistanceMetrics` which needs to be open in a non intuitive order, please let me know if you prefer I rejig this in some way.

I think one approach would be to put `RequireQualifiedAccess` for the `Vector` module, but would incur more impact in client code.

https://learn.microsoft.com/en-us/dotnet/fsharp/style-guide/component-design-guidelines#consider-using-requirequalifiedaccess-and-carefully-apply-autoopen-attributes

- [x] The project builds without problems on your machine
- [ ] Added unit tests regarding the added features
- [x] Checked the documentation builds and gave it a quick look