### PR TITLE
Support intersect of mixed interval types

### DIFF
--- a/src/FSharp.Stats/Interval.fs
+++ b/src/FSharp.Stats/Interval.fs
@@ -288,92 +288,156 @@ module Interval =
         | Interval.Empty,Interval.Empty -> Interval.Empty
         | _ -> failwithf "Subtraction of (half) open intervals is not supported!"
         
-    // a0----a1
-    //     b0-----b1
-    /// <summary>Checking for intersection of both intervals</summary>
-    /// <remarks></remarks>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <returns></returns>
-    /// <example>
-    /// <code>
-    /// </code>
-    /// </example>
-    let inline isIntersection (a: Interval<'a>) b =
+
+    /// <summary>Checks if two intervals intersect</summary>
+    /// <param name="a">The first interval</param>
+    /// <param name="b">The second interval</param>
+    /// <returns>True if the intervals intersect, false otherwise</returns>
+    let inline isIntersection a b =
         match a,b with
+        | Interval.Empty, Interval.Empty  -> true
+        | Interval.Empty, _ | _, Interval.Empty -> false
         | Interval.Closed (minA,maxA), Interval.Closed (minB,maxB) -> minA <= maxB && minB <= maxA
-        | Interval.Closed (minA,maxA), Interval.Open (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.Closed (minA,maxA), Interval.RightOpen (minB,maxB) -> minA < maxB && minB <= maxA
-        | Interval.Closed (minA,maxA), Interval.LeftOpen (minB,maxB) -> minA <= maxB && minB < maxA
-        | Interval.Closed (_,_), Interval.Empty -> false
-        | Interval.Open (minA,maxA), Interval.Closed (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.Open (minA,maxA), Interval.Open (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.Open (minA,maxA), Interval.RightOpen (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.Open (minA,maxA), Interval.LeftOpen (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.Open (_,_), Interval.Empty -> false
-        | Interval.LeftOpen (minA,maxA), Interval.Closed (minB,maxB) -> minA < maxB && minB <= maxA
-        | Interval.LeftOpen (minA,maxA), Interval.Open (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.LeftOpen (minA,maxA), Interval.RightOpen (minB,maxB) -> minA <= maxB && minB <= maxA
-        | Interval.LeftOpen (minA,maxA), Interval.LeftOpen (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.LeftOpen (_,_), Interval.Empty -> false
-        | Interval.RightOpen (minA,maxA), Interval.Closed (minB,maxB) -> minA <= maxB && minB < maxA
-        | Interval.RightOpen (minA,maxA), Interval.Open (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.RightOpen (minA,maxA), Interval.RightOpen (minB,maxB) -> minA < maxB && minB < maxA
-        | Interval.RightOpen (minA,maxA), Interval.LeftOpen (minB,maxB) -> minA <= maxB && minB <= maxA
-        | Interval.RightOpen (_,_), Interval.Empty -> false
-        | Interval.Empty, Interval.Closed (_,_) -> false
-        | Interval.Empty, Interval.Open (_,_) -> false
-        | Interval.Empty, Interval.LeftOpen (_,_) -> false
-        | Interval.Empty, Interval.RightOpen (_,_) -> false
-        | Interval.Empty,Interval.Empty -> true
+        | Interval.Open (minA,maxA), Interval.Open (minB,maxB) 
+        | Interval.LeftOpen (minA,maxA), Interval.LeftOpen (minB,maxB)
+        | Interval.RightOpen (minA,maxA), Interval.RightOpen (minB,maxB) -> minA < maxB && minB < maxA && max minA minB < min maxA maxB
+        | Interval.Open (minB,maxB), Interval.Closed (minA,maxA)
+        | Interval.Closed (minA,maxA), Interval.Open (minB,maxB) -> (minB < minA && maxB > minA) || (minB >= minA && ((maxB <= maxA && minB <> maxB) || (minB < maxA && maxB > maxA)))
+        | Interval.RightOpen (minB,maxB), Interval.Closed (minA,maxA)
+        | Interval.Closed (minA,maxA), Interval.RightOpen (minB,maxB) -> minA < maxB && minB <= maxA && not (maxB <= maxA && max minA minB = maxB)
+        | Interval.LeftOpen (minB,maxB), Interval.Closed (minA,maxA)
+        | Interval.Closed (minA,maxA), Interval.LeftOpen (minB,maxB) -> minA <= maxB && minB < maxA && not (minB >= minA && min maxA maxB = minB)
+        | Interval.RightOpen (minB,maxB), Interval.Open (minA,maxA)
+        | Interval.Open (minA,maxA), Interval.RightOpen (minB,maxB) -> minA < maxB && minB < maxA && not ((minB > minA && min maxA maxB = minB) || min maxA maxB = minA)
+        | Interval.LeftOpen (minB,maxB), Interval.Open (minA,maxA)
+        | Interval.Open (minA,maxA), Interval.LeftOpen (minB,maxB) -> minA < maxB && minB < maxA && not((maxB < maxA && max minA minB = maxB) || max minA minB = maxA)
+        | Interval.RightOpen (minB,maxB), Interval.LeftOpen (minA,maxA)
+        | Interval.LeftOpen (minA,maxA), Interval.RightOpen (minB,maxB) -> minA <= maxB && minB <= maxA && not((maxB <= maxA && (minA = maxB || (minA < minB && minB = maxB)) || minA = maxA))
         
 
-    /// <summary>Returns the intersection of this interval with another.</summary>
-    /// <remarks></remarks>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <returns></returns>
-    /// <example>
-    /// <code>
-    /// </code>
-    /// </example>
-    let inline intersect (a: Interval<'a>) b =
-        if not (isIntersection a b) then
-            Interval.Empty
-        else
-            match a,b with
-            | Interval.Closed (minA,maxA), Interval.Closed (minB,maxB) -> 
-                if not (minA <= maxB && minB <= maxA) then
+    /// <summary>Returns the intersection of two intervals</summary>
+    /// <param name="a">The first interval</param>
+    /// <param name="b">The second interval</param>
+    /// <returns>The intersection of the two intervals</returns>
+    /// <exception cref="System.Exception">Thrown when trying to intersect mixed interval types</exception>
+    let inline intersect a b =
+        match a,b with
+        | Interval.Empty, _ | _, Interval.Empty -> Interval.Empty
+        | Interval.Closed (minA,maxA), Interval.Closed (minB,maxB) -> 
+            if minA <= maxB && minB <= maxA then 
+                Interval.Closed(max minA minB, min maxA maxB)
+            else 
+                Interval.Empty
+        | Interval.Open (minA,maxA), Interval.Open (minB,maxB) -> 
+            let min' = max minA minB
+            let max' = min maxA maxB
+            if min' < max' then 
+                Interval.Open(min',max')
+            else 
+                Interval.Empty
+        | Interval.LeftOpen (minA,maxA), Interval.LeftOpen (minB,maxB) -> 
+            let min' = max minA minB
+            let max' = min maxA maxB
+            if min' < max' then 
+                Interval.LeftOpen(min',max')
+            else 
+                Interval.Empty
+        | Interval.RightOpen (minA,maxA), Interval.RightOpen (minB,maxB) -> 
+            let min' = max minA minB
+            let max' = min maxA maxB
+            if min' < max' then 
+                Interval.RightOpen(min',max')
+            else 
+                Interval.Empty
+        | Interval.Open (minB,maxB), Interval.Closed (minA,maxA)
+        | Interval.Closed (minA,maxA), Interval.Open (minB,maxB) -> 
+            if minB >= minA then 
+                if maxB <= maxA then 
+                    if minB = maxB then 
                         Interval.Empty
+                    else
+                        Interval.Open(minB,maxB)
+                elif minB >= maxA then 
+                    Interval.Empty
                 else
-                    let min' = max minA minB
-                    let max' = min maxA maxB
-                    Interval.Closed (min',max') 
-            | Interval.Closed (min,max), Interval.Empty -> Interval.Empty
-            | Interval.Empty, Interval.Closed (min,max) -> Interval.Empty
-            | Interval.Empty,Interval.Empty -> Interval.Empty
-            | Interval.LeftOpen (minA,maxA), Interval.LeftOpen (minB,maxB) -> 
-                if not (minA < maxB && minB < maxA) then
+                    Interval.LeftOpen(minB,maxA)
+            else
+                if maxB <= maxA then 
+                    if maxB <= minA then 
                         Interval.Empty
+                    else
+                        Interval.RightOpen(minA,maxB)
+                else Interval.Closed(minA,maxA)
+        | Interval.RightOpen (minB,maxB), Interval.Closed (minA,maxA)
+        | Interval.Closed (minA,maxA), Interval.RightOpen (minB,maxB) ->
+            let min' = max minA minB
+            if maxB <= maxA then 
+                if min' >= maxB then 
+                    Interval.Empty
                 else
-                    let min' = max minA minB
-                    let max' = min maxA maxB
-                    Interval.LeftOpen (min',max')
-            | Interval.RightOpen (minA,maxA), Interval.RightOpen (minB,maxB) ->
-                if not (minA < maxB && minB < maxA) then
+                    Interval.RightOpen(min',maxB)
+            elif min' <= maxA then
+                Interval.Closed(min',maxA)
+            else 
+                Interval.Empty
+        | Interval.LeftOpen (minB,maxB), Interval.Closed (minA,maxA)
+        | Interval.Closed (minA,maxA), Interval.LeftOpen (minB,maxB) ->
+            let max' = min maxA maxB
+            if minB >= minA then 
+                if max' <= minB then 
+                    Interval.Empty
+                else
+                    Interval.LeftOpen(minB,max')
+            elif minA <= max' then
+                Interval.Closed(minA,max')
+            else 
+                Interval.Empty
+        | Interval.RightOpen (minB,maxB), Interval.Open (minA,maxA)
+        | Interval.Open (minA,maxA), Interval.RightOpen (minB,maxB) ->
+            let max' = min maxA maxB
+            if minB > minA then 
+                if max' <= minB then 
+                    Interval.Empty
+                else
+                    Interval.RightOpen(minB,max')
+            elif minA >= max' then 
+                Interval.Empty
+            else
+                Interval.Open(minA,max')
+        | Interval.LeftOpen (minB,maxB), Interval.Open (minA,maxA)
+        | Interval.Open (minA,maxA), Interval.LeftOpen (minB,maxB) -> 
+            let min' = max minA minB
+            if maxB < maxA then 
+                if min' >= maxB then 
+                    Interval.Empty
+                else
+                    Interval.LeftOpen(min',maxB)
+            elif min' >= maxA then
+                Interval.Empty
+            else 
+                Interval.Open(min',maxA)
+        | Interval.RightOpen (minB,maxB), Interval.LeftOpen (minA,maxA)
+        | Interval.LeftOpen (minA,maxA), Interval.RightOpen (minB,maxB) -> 
+            if maxB <= maxA then
+                if minA >= minB then 
+                    if minA >= maxB then 
                         Interval.Empty
+                    else
+                        Interval.Open(minA,maxB)
+                elif minB >= maxB then 
+                    Interval.Empty
                 else
-                    let min' = max minA minB
-                    let max' = min maxA maxB
-                    Interval.RightOpen (min',max')
-            | Interval.Open (minA,maxA), Interval.Open (minB,maxB) ->
-                if not (minA < maxB && minB < maxA) then
+                    Interval.RightOpen(minB,maxB)
+            else    
+                if minA >= minB then 
+                    if minA >= maxA then 
                         Interval.Empty
-                else
-                    let min' = max minA minB
-                    let max' = min maxA maxB
-                    Interval.Open (min',max')
-            | _ -> failwithf "Intersection of mixed interval types is not supported!"
+                    else
+                        Interval.LeftOpen(minA,maxA)
+                elif minB <= maxA then
+                    Interval.Closed(minB,maxA)
+                else 
+                    Interval.Empty    
 
     /// <summary>Get the value at a given percentage within (0.0 - 1.0) or outside (&lt; 0.0, &gt; 1.0) of the interval. Rounding to nearest neighbour occurs when needed.</summary>
     /// <remarks></remarks>

--- a/tests/FSharp.Stats.Tests/Interval.fs
+++ b/tests/FSharp.Stats.Tests/Interval.fs
@@ -256,8 +256,8 @@ let intervalTests =
             Expect.equal actualFalse expectedFalse "Intervals do not intersect"
             
             let actualFalse2 = 
-                let i1 = Interval.Open (3,5)
-                let i2 = Interval.Open (5,9)
+                let i1 = Interval.RightOpen (3,5)
+                let i2 = Interval.LeftOpen (5,9)
                 Interval.isIntersection i1 i2
             Expect.equal actualFalse2 false "Intervals (3,5) and (5,9) do not intersect"
             

--- a/tests/FSharp.Stats.Tests/Interval.fs
+++ b/tests/FSharp.Stats.Tests/Interval.fs
@@ -253,7 +253,13 @@ let intervalTests =
                 let i2 = Interval.CreateClosed<float> (-infinity,-6.)
                 Interval.isIntersection i1 i2
             let expectedFalse = false
-            Expect.equal actual expected "Intervals do not intersect"
+            Expect.equal actualFalse expectedFalse "Intervals do not intersect"
+            
+            let actualFalse2 = 
+                let i1 = Interval.Open (3,5)
+                let i2 = Interval.Open (5,9)
+                Interval.isIntersection i1 i2
+            Expect.equal actualFalse2 false "Intervals (3,5) and (5,9) do not intersect"
             
             let actualCE = 
                 let i1 = Interval.CreateClosed<float> (-5.,5.5)
@@ -431,6 +437,155 @@ let intervalTests =
                 Interval.intersect i1 i2
             let expectedStrT = Interval.CreateClosed<string> ("d","d")
             Expect.equal actualStrT expectedStrT "String intervals do intersect"
+
+            let actualCO1 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateOpen<int> (1,4)
+                Interval.intersect i1 i2
+            let expectedCO1 = Interval.CreateRightOpen<int> (3,4)
+            Expect.equal actualCO1 expectedCO1 "Interval intersect is calculated incorrectly"
+
+            let actualCO2 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateOpen<int> (4,7)
+                Interval.intersect i1 i2
+            let expectedCO2 = Interval.CreateLeftOpen<int> (4,6)
+            Expect.equal actualCO2 expectedCO2 "Interval intersect is calculated incorrectly"
+
+            let actualCO3 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateOpen<int> (4,5)
+                Interval.intersect i1 i2
+            let expectedCO3 = Interval.CreateOpen<int> (4,5)
+            Expect.equal actualCO3 expectedCO3 "Interval intersect is calculated incorrectly"
+
+            let actualCO4 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateOpen<int> (1,7)
+                Interval.intersect i1 i2
+            let expectedCO4 = Interval.CreateClosed<int> (3,6)
+            Expect.equal actualCO4 expectedCO4 "Interval intersect is calculated incorrectly"
+
+            let actualCO5 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateOpen<int> (1,3)
+                Interval.intersect i1 i2
+            let expectedCO5 = Interval.Empty
+            Expect.equal actualCO5 expectedCO5 "Interval intersect is calculated incorrectly"
+
+            let actualCLO1 =
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateLeftOpen<int> (1,4)
+                Interval.intersect i1 i2
+            let expectedCLO1 = Interval.CreateClosed<int> (3,4)
+            Expect.equal actualCLO1 expectedCLO1 "Interval intersect is calculated incorrectly"
+
+            let actualCLO2 =
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateLeftOpen<int> (4,7)
+                Interval.intersect i1 i2
+            let expectedCLO2 = Interval.CreateLeftOpen<int> (4,6)
+            Expect.equal actualCLO2 expectedCLO2 "Interval intersect is calculated incorrectly"
+
+            let actualCLO3 =
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateLeftOpen<int> (4,5)
+                Interval.intersect i1 i2
+            let expectedCLO3 = Interval.CreateLeftOpen<int> (4,5)
+            Expect.equal actualCLO3 expectedCLO3 "Interval intersect is calculated incorrectly"
+
+            let actualCLO4 =
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateLeftOpen<int> (1,7)
+                Interval.intersect i1 i2
+            let expectedCLO4 = Interval.CreateClosed<int> (3,6)
+            Expect.equal actualCLO4 expectedCLO4 "Interval intersect is calculated incorrectly"
+
+            let actualCLO5 =
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateLeftOpen<int> (1,3)
+                Interval.intersect i1 i2
+            let expectedCLO5 = Interval.CreateClosed<int> (3,3)
+            Expect.equal actualCLO5 expectedCLO5 "Interval intersect is calculated incorrectly"
+
+            let actualCRO1 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (1,4)
+                Interval.intersect i1 i2
+            let expectedCRO1 = Interval.CreateRightOpen<int> (3,4)
+            Expect.equal actualCRO1 expectedCRO1 "Interval intersect is calculated incorrectly"
+
+            let actualCRO2 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (4,7)
+                Interval.intersect i1 i2
+            let expectedCRO2 = Interval.CreateClosed<int> (4,6)
+            Expect.equal actualCRO2 expectedCRO2 "Interval intersect is calculated incorrectly"
+
+            let actualCRO3 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (4,5)
+                Interval.intersect i1 i2
+            let expectedCRO3 = Interval.CreateRightOpen<int> (4,5)
+            Expect.equal actualCRO3 expectedCRO3 "Interval intersect is calculated incorrectly"
+
+            let actualCRO4 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (1,7)
+                Interval.intersect i1 i2
+            let expectedCRO4 = Interval.CreateClosed<int> (3,6)
+            Expect.equal actualCRO4 expectedCRO4 "Interval intersect is calculated incorrectly"
+
+            let actualCRO5 = 
+                let i1 = Interval.CreateClosed<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (1,3)
+                Interval.intersect i1 i2
+            let expectedCRO5 = Interval.Empty
+            Expect.equal actualCRO5 expectedCRO5 "Interval intersect is calculated incorrectly"
+
+            let actualROLO1 = 
+                let i1 = Interval.CreateLeftOpen<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (1,4)
+                Interval.intersect i1 i2
+            let expectedROLO1 = Interval.CreateOpen<int> (3,4)
+            Expect.equal actualROLO1 expectedROLO1 "Interval intersect is calculated incorrectly"
+
+            let actualROLO2 = 
+                let i1 = Interval.CreateLeftOpen<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (4,7)
+                Interval.intersect i1 i2
+            let expectedROLO2 = Interval.CreateClosed<int> (4,6)
+            Expect.equal actualROLO2 expectedROLO2 "Interval intersect is calculated incorrectly"
+
+            let actualROLO3 = 
+                let i1 = Interval.CreateLeftOpen<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (4,5)
+                Interval.intersect i1 i2
+            let expectedROLO3 = Interval.CreateRightOpen<int> (4,5)
+            Expect.equal actualROLO3 expectedROLO3 "Interval intersect is calculated incorrectly"
+
+            let actualROLO4 = 
+                let i1 = Interval.CreateLeftOpen<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (1,7)
+                Interval.intersect i1 i2
+            let expectedROLO4 = Interval.CreateLeftOpen<int> (3,6)
+            Expect.equal actualROLO4 expectedROLO4 "Interval intersect is calculated incorrectly"
+
+            let actualROLO5 = 
+                let i1 = Interval.CreateLeftOpen<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (1,3)
+                Interval.intersect i1 i2
+            let expectedROLO5 = Interval.Empty
+            Expect.equal actualROLO5 expectedROLO5 "Interval intersect is calculated incorrectly"
+
+            let actualROLO6 =
+                let i1 = Interval.CreateLeftOpen<int> (3,6)
+                let i2 = Interval.CreateRightOpen<int> (6,9)
+                Interval.intersect i1 i2
+            let expectedROLO6 = Interval.CreateClosed<int> (6,6)
+            Expect.equal actualROLO6 expectedROLO6 "Interval intersect is calculated incorrectly"
+
+                
             )
 
 


### PR DESCRIPTION
Closes #324, Closes #323 

- Fix `isIntersection` bug
- Add support for intersect of mixed interval types (intersect of `LeftOpen` with `RightOpen` for example)

**Description**

Adds support for intersect on mixed interval types. Added tests for `isIntersect` as well as `intersect`.  Ran FsCheck against both functions, could include those tests too if needed/wanted.

**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
