### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -281,17 +281,17 @@ module Array =
     /// <code>
     /// </code>
     /// </example>
-    let inline varOf mean (items: 'T []) =
+    let inline varOf mean (items: 'T []) : 'T =
         
-        let mutable variance = LanguagePrimitives.GenericZero
-        let mutable length = LanguagePrimitives.GenericZero
+        let mutable variance = LanguagePrimitives.GenericZero<'T>
+        let mutable length = LanguagePrimitives.GenericZero<'T>
                 
         for i = 0 to items.Length-1 do
             let z = items[i] - mean
             variance <- variance + (z * z)
-            length <- length + LanguagePrimitives.GenericOne
+            length <- length + LanguagePrimitives.GenericOne<'T>
         
-        variance / (length - LanguagePrimitives.GenericOne)
+        variance / (length - LanguagePrimitives.GenericOne<'T>)
 
 
     /// <summary>Computes the Weighted Variance</summary>

--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -281,15 +281,17 @@ module Array =
     /// <code>
     /// </code>
     /// </example>
-    let inline varOf mean (items:array<'T>) =
+    let inline varOf mean (items: 'T []) =
         
-        let mutable variance = LanguagePrimitives.GenericZero< 'T > 
+        let mutable variance = LanguagePrimitives.GenericZero
+        let mutable length = LanguagePrimitives.GenericZero
                 
         for i = 0 to items.Length-1 do
             let z = items[i] - mean
             variance <- variance + (z * z)
+            length <- length + LanguagePrimitives.GenericOne
         
-        variance / float (items.Length - 1)
+        variance / (length - LanguagePrimitives.GenericOne)
 
 
     /// <summary>Computes the Weighted Variance</summary>

--- a/src/FSharp.Stats/Matrix.fs
+++ b/src/FSharp.Stats/Matrix.fs
@@ -602,7 +602,7 @@ module Matrix =
     /// <code>
     /// </code>
     /// </example>
-    let ofRows (rows: Vector<RowVector<'T>>) = DS.seqDenseMatrixDS rows |> MS.dense
+    let ofRows (rows: Vector<RowVector<_>>) = DS.seqDenseMatrixDS rows |> MS.dense
     /// <summary>returns a dense matrix with the inner vectors of the input rowvector as its columns</summary>
     /// <remarks></remarks>
     /// <param name="cols"></param>
@@ -611,7 +611,7 @@ module Matrix =
     /// <code>
     /// </code>
     /// </example>
-    let ofCols (cols: RowVector<Vector<'T>>) = DS.colSeqDenseMatrixDS cols |> MS.dense
+    let ofCols (cols: RowVector<Vector<_>>) = DS.colSeqDenseMatrixDS cols |> MS.dense
     /// <summary>reads matrix from delimiter separated file</summary>
     /// <remarks></remarks>
     /// <param name="path"></param>

--- a/src/FSharp.Stats/Ops.fs
+++ b/src/FSharp.Stats/Ops.fs
@@ -166,7 +166,7 @@ module Ops =
         
 
 
-    let inline nthroot n (A:'T) : 'U =
+    let inline nthroot n A : 'U =
         let rec f x =
             let m = n - 1
             let m' = multByInt32 x m

--- a/src/FSharp.Stats/Quantile.fs
+++ b/src/FSharp.Stats/Quantile.fs
@@ -6,7 +6,7 @@ module Quantile =
 
     type QuantileFunction<'a> =  float -> array<'a> -> float
 
-    let private quantileHelper (quatileF : QuantileFunction<'a>) q (data:array<'a>) =
+    let inline private quantileHelper (quatileF : QuantileFunction<'a>) q (data:array<'a>) =
 
         if (q < 0. || q > 1. || data.Length = 0) then
             nan
@@ -194,7 +194,7 @@ module Quantile =
         /// </code>
         /// </example>
         let normalInPLace q (data:array<_>) =
-            let f q (data:array<'a>) =                
+            let f q (data:_[]) =                
                 let h  = (float data.Length + 0.25) * q + 0.375
                 let h' = int h
                 let a = Array.quickSelectInPlace (h') data |> float //TM
@@ -378,7 +378,7 @@ module Quantile =
         /// </code>
         /// </example>
         let normal q (data:array<_>) =
-            let f q (data:array<'a>) =                
+            let f q (data:float[]) =                
                 let h  = (float data.Length + 0.25) * q + 0.375
                 let h' = int h
                 let a = data.[ max (h' - 1) 0]
@@ -527,7 +527,7 @@ module Quantile =
     /// <code>
     /// </code>
     /// </example>
-    let normal q (data:seq<_>) =
+    let normal q (data:float seq) =
         let data' = Seq.UtilityFunctions.toArrayCopyQuick data
         InPlace.normalInPLace q data'
 

--- a/src/FSharp.Stats/Rank.fs
+++ b/src/FSharp.Stats/Rank.fs
@@ -32,7 +32,7 @@ module Rank =
     /// </code>
     /// </example>
     let inline internal compNaNFirst<'U when 'U :> System.IComparable> = 
-        System.Collections.Generic.Comparer.Default
+        System.Collections.Generic.Comparer<'U>.Default
         
     /// <summary>Ranks each entry of the given unsorted data array. Use 'breakTies function to break ties</summary>
     /// <remarks></remarks>

--- a/src/FSharp.Stats/ServiceLocator.fs
+++ b/src/FSharp.Stats/ServiceLocator.fs
@@ -183,7 +183,7 @@ module ServiceLocator =
             | ServiceDisabled                          -> "Disabled"           
             | ServiceEnabledFailed                     -> "Failed to start"
             | ServiceEnabledUninitialised              -> "Will auto enable on demand"
-            | ServiceEnabledOK (service,justification) -> "Enabled\n" ^ justification
+            | ServiceEnabledOK (service,justification) -> "Enabled\n" + justification
 
   
 

--- a/tests/FSharp.Stats.Tests/Array.fs
+++ b/tests/FSharp.Stats.Tests/Array.fs
@@ -70,6 +70,20 @@ let linspaceTests =
             let expected = Array.linspace(start= -3.5,stop= 30.1,num=6,IncludeEndpoint=false)
             let actual = [|-3.5;  2.1;  7.7; 13.3; 18.9; 24.5|]
             TestExtensions.sequenceEqual (Accuracy.high) actual expected "linspace results in wrong array"
-      
-        
+    ]
+
+
+[<Tests>]
+let varianceTests =
+    testList "Array" [
+        testCase "variance float" <| fun () ->
+            let testArray = [|1.; 2.; 3.; 4.; 5.|]
+            let expected = 2.5
+            let actual = Array.varOf (Array.average testArray) testArray
+            Expect.floatClose Accuracy.high actual expected "Variance is incorrect"
+        testCase "variance float32" <| fun () ->
+            let testArray = [|1.f; 2.f; 3.f; 4.f; 5.f|]
+            let expected = 2.5f
+            let actual : float32 = Array.varOf (Array.average testArray) testArray
+            Expect.floatClose Accuracy.high (float actual) (float expected) "Variance is incorrect"
     ]

--- a/tests/FSharp.Stats.Tests/Interval.fs
+++ b/tests/FSharp.Stats.Tests/Interval.fs
@@ -15,7 +15,7 @@ let intervalTests =
         testCase "create" (fun _ -> 
 
             let expected = Interval.Closed (-5.,5.)
-            let actual = Interval.CreateClosed (-5.,5.)
+            let actual = Interval.Closed (-5.,5.)
             Expect.equal expected actual "Instantiation of Interval.Closed is incorrect"
         
             //let expectedError() = Intervals.create 5. -5. |> ignore

--- a/tests/FSharp.Stats.Tests/ML.fs
+++ b/tests/FSharp.Stats.Tests/ML.fs
@@ -313,34 +313,33 @@ module hClust =
     open HierarchicalClustering
     open FSharpAux
     let datapath = @"data/testDatahClust.csv"
-    let lables,data =
-        fromFileWithSep ',' datapath
-        |> Seq.skip 1
-        |> Seq.map (fun arr -> arr.[4], [| float arr.[0]; float arr.[1]; float arr.[2]; float arr.[3]; |])
-        |> Seq.toArray
-        |> Array.mapi (fun i (lable,data) -> sprintf "%s_%i" lable i, data)
-        |> Array.unzip
-    let distance = FSharp.Stats.DistanceMetrics.euclidean
-    let linker = Linker.singleLwLinker
-    let testCluster = generate<float[]> distance linker data |> Seq.item 0 |> (fun x -> x.Key)
-    let testLeaf = createClusterValue 1 [|1.;2.|]
-    let testLeaf2 = createClusterValue 2 [|3.;4.|]
-    let testSingleCluster = createCluster 1 0.4 testLeaf testLeaf2
-    let testClusterList = get testCluster |> Seq.toArray |> Array.mapi (fun i x -> i,x)
-    let cachedDist = DistanceCaching<float[]> (distance,linker)
 
     
-    [<Tests>]
-    let hClustTests = 
-        testList "hClust Tests" [
+    let inline hClustTests name rounding (fromFloat : float -> 'a) (parse : string -> 'a) = 
+        let lables,data =
+            fromFileWithSep ',' datapath
+            |> Seq.skip 1
+            |> Seq.map (fun arr -> arr.[4], [| parse arr.[0]; parse arr.[1]; parse arr.[2]; parse arr.[3]; |])
+            |> Seq.toArray
+            |> Array.mapi (fun i (lable,data) -> sprintf "%s_%i" lable i, data)
+            |> Array.unzip
+        let distance x y = FSharp.Stats.DistanceMetrics.euclidean x y |> float
+        let linker = Linker.singleLwLinker
+        let testCluster = generate<'a[]> distance linker data |> Seq.item 0 |> (fun x -> x.Key)
+        let testLeaf = createClusterValue 1 [|fromFloat 1.; fromFloat 2.|]
+        let testLeaf2 = createClusterValue 2 [|fromFloat 3.;fromFloat 4.|]
+        let testSingleCluster = createCluster 1 0.4 testLeaf testLeaf2
+        let testClusterList = get testCluster |> Seq.toArray |> Array.mapi (fun i x -> i,x)
+        let cachedDist = DistanceCaching<'a[]> (distance,linker)
+        testList name [
             testCase "simple cluster" <| fun () ->
                 let testSet =  
                     [|(0, (0.6164414287, 5, 15)); (1, (0.4123105705, 14, 11));
                         (2, (0.3000000119, 1, 13)); (3, (0.2645751238, 12, 6));
                         (4, (0.2449489683, 2, 3)); (5, (0.1732050776, 10, 9));
                         (6, (0.1414213628, 0, 4)); (7, (0.0, 7, 8))|]
-                    |> Array.map (fun (a,(b,c,d)) -> (a,((Math.round 5 b),c,d) ))
-                let actualSet = testClusterList |> Array.map (fun (a,(b,c,d)) -> (a,((Math.round 5 b),c,d) ))
+                    |> Array.map (fun (a,(b,c,d)) -> (a,((Math.round (rounding/2) b),c,d) ))
+                let actualSet = testClusterList |> Array.map (fun (a,(b,c,d)) -> (a,((Math.round (rounding/2) b),c,d) ))
  
                 Expect.equal actualSet testSet "clusters aren't same "
 
@@ -349,43 +348,47 @@ module hClust =
                 Expect.equal testEuclidean 0. "euclidean distance - same values check"
                 Expect.equal (euclidean [|1.;2.;4.|][|3.;-2.;4.|] |> Math.round 5) 4.47214 "euclidean distance - negative check "
             testCase "create Clusters and Leafs "<| fun () -> 
-                let testSingleCluster = Node (1, 0.4, 2, Leaf (1, 1, [|1.0; 2.0|]), Leaf (2, 1, [|-3.0; 4.0|]))
-                let testLeaf1 = Leaf (1, 1, [|1.0; 2.0|])
-                let testLeaf2 = Leaf (2, 1, [|-3.0; 4.0|])
-                Expect.equal (createClusterValue 1 [|1.;2.|]) testLeaf1 "creating Leaf failed"
-                Expect.equal (createClusterValue 2 [|-3.;4.|]) testLeaf2 "creating Leaf failed"
+                let testSingleCluster = Node (1, 0.4, 2, Leaf (1, 1, [|fromFloat 1.0; fromFloat 2.0|]), Leaf (2, 1, [|fromFloat -3.0; fromFloat 4.0|]))
+                let testLeaf1 = Leaf (1, 1, [|fromFloat 1.0; fromFloat 2.0|])
+                let testLeaf2 = Leaf (2, 1, [|fromFloat -3.0; fromFloat 4.0|])
+                Expect.equal (createClusterValue 1 [|fromFloat 1.;fromFloat 2.|]) testLeaf1 "creating Leaf failed"
+                Expect.equal (createClusterValue 2 [|fromFloat -3.;fromFloat 4.|]) testLeaf2 "creating Leaf failed"
                 Expect.equal (createCluster 1 0.4 testLeaf testLeaf2) testSingleCluster "creating Cluster failed "
                 Expect.equal (getClusterId testLeaf1 ) 1 "getClusterID Leaf"
                 Expect.equal (getClusterId testLeaf2 ) 2 "getClusterID Leaf"
                 Expect.equal (getClusterId testSingleCluster ) 1 "getClusterID Clust"
             testCase "getValues" <| fun () -> 
-                let testDistances = [0.0; 0.1414213628; 0.1732050776; 0.2449489683; 0.2645751238; 0.3000000119;0.4123105705; 0.6164414287] |> List.map (fun x -> Math.round 10 x)
-                let allLeafs =   [[|5.0; 3.4; 1.5; 0.2|]; [|5.0; 3.4; 1.5; 0.2|]; [|5.0; 3.6; 1.4; 0.2|];[|5.1; 3.5; 1.4; 0.2|]; [|4.6; 3.4; 1.4; 0.3|]; [|4.6; 3.1; 1.5; 0.2|];[|4.7; 3.2; 1.3; 0.2|]; [|4.9; 3.0; 1.4; 0.2|]; [|5.4; 3.9; 1.7; 0.4|]]
+                let testDistances = [0.0; 0.1414213628; 0.1732050776; 0.2449489683; 0.2645751238; 0.3000000119;0.4123105705; 0.6164414287] |> List.map (fun x -> Math.round rounding x)
+                let allLeafs =   [[|5.0; 3.4; 1.5; 0.2|]; [|5.0; 3.4; 1.5; 0.2|]; [|5.0; 3.6; 1.4; 0.2|];[|5.1; 3.5; 1.4; 0.2|]; [|4.6; 3.4; 1.4; 0.3|]; [|4.6; 3.1; 1.5; 0.2|];[|4.7; 3.2; 1.3; 0.2|]; [|4.9; 3.0; 1.4; 0.2|]; [|5.4; 3.9; 1.7; 0.4|]] |> List.map (Array.map fromFloat)
                 Expect.equal (tryGetLeafValue testSingleCluster) None "tryGetLeafValue failed"
-                Expect.equal (tryGetLeafValue testLeaf) (Some [|1.0;2.0|]) "tryGetLeafValue failed"
+                Expect.equal (tryGetLeafValue testLeaf) (Some [|fromFloat 1.0;fromFloat 2.0|]) "tryGetLeafValue failed"
                 Expect.equal (getClusterMemberCount testLeaf ) 1 "MemberCount off"
                 Expect.equal (getClusterMemberCount testSingleCluster ) 2 "MemberCount off"
                 Expect.equal (getClusterMemberCount testCluster) 9 "MemberCount off "
-                Expect.equal (getDistancesOfCluster testCluster|> List.map (fun x -> Math.round 10 x))  testDistances "testDistances off"
+                Expect.equal (getDistancesOfCluster testCluster|> List.map (fun x -> Math.round rounding x))  testDistances "testDistances off"
                 Expect.equal (getLeafsOfCluster testCluster ) allLeafs "Leaf retrieval failed "
-                Expect.equal (getLeafsOfCluster testLeaf ) [[|1.0; 2.0|]] "Leaf retrieval failed"
+                Expect.equal (getLeafsOfCluster testLeaf ) [[|fromFloat 1.0; fromFloat 2.0|]] "Leaf retrieval failed"
                 Expect.equal (getLeafNamesOfCluster testCluster) [8; 7; 4; 0; 6; 3; 2; 1; 5] "ID retrieve failed "
                 Expect.equal (getLeafNamesOfCluster testLeaf) [1] "ID retrieve failed"
                 Expect.equal (getLeftChild testSingleCluster ) testLeaf "left child failed"
                 Expect.equal (getRightChild testSingleCluster ) testLeaf2 "right child failed"
-                Expect.equal (getLeftChild testCluster ) (Leaf(5, 1, [|5.4; 3.9; 1.7; 0.4|])) "complex left child failed"
+                Expect.equal (getLeftChild testCluster ) (Leaf(5, 1, [|fromFloat 5.4; fromFloat 3.9; fromFloat 1.7; fromFloat 0.4|])) "complex left child failed"
                 Expect.equal (getDistance testSingleCluster ) 0.4 "getDistance failed"
                 Expect.equal (getDistance testLeaf) -1. "getDistance at Leaf failed"
                 Expect.equal 
-                    (usedDistancesAndLabels testCluster  |> List.map (fun x -> (Math.round 10 (fst x) ,snd x )  ))
-                      ([(0.0, [9]); (0.1414213628, [10]); (0.1732050776, [11]);(0.2449489683, [12]); (0.2645751238, [13]); (0.3000000119, [14]);(0.4123105705, [15]); (0.6164414287, [16])] |> List.map (fun x -> (Math.round 10 (fst x) ,snd x )  ))
+                    (usedDistancesAndLabels testCluster  |> List.map (fun x -> (Math.round rounding (fst x) ,snd x )  ))
+                      ([(0.0, [9]); (0.1414213628, [10]); (0.1732050776, [11]);(0.2449489683, [12]); (0.2645751238, [13]); (0.3000000119, [14]);(0.4123105705, [15]); (0.6164414287, [16])] |> List.map (fun x -> (Math.round rounding (fst x) ,snd x )  ))
                     "used Distances and Labels won't work "
                 Expect.equal 
-                    (getDistancesAndLabels testCluster  |> List.map (fun x -> (fst x ,Math.round 10 (snd x )  )))
-                      ([(9, 0.0); (10, 0.1414213628); (11, 0.1732050776); (12, 0.2449489683);(13, 0.2645751238); (14, 0.3000000119); (15, 0.4123105705);(16, 0.6164414287)]|> List.map (fun x -> (fst x ,Math.round 10 (snd x ))))
+                    (getDistancesAndLabels testCluster  |> List.map (fun x -> (fst x ,Math.round rounding (snd x )  )))
+                      ([(9, 0.0); (10, 0.1414213628); (11, 0.1732050776); (12, 0.2449489683);(13, 0.2645751238); (14, 0.3000000119); (15, 0.4123105705);(16, 0.6164414287)]|> List.map (fun x -> (fst x ,Math.round rounding (snd x ))))
 
                      "Distances and Labels won't work "
         ]
+    [<Tests>]
+    let hClustTestsFloat = hClustTests "hClust Tests" 10 id float
+    [<Tests>]
+    let hClustTestsFloat32 = hClustTests "hClust Tests float32" 4 float32 float32
 
 module KNN =
     open FSharp.Stats.ML.Unsupervised

--- a/tests/FSharp.Stats.Tests/Signal.fs
+++ b/tests/FSharp.Stats.Tests/Signal.fs
@@ -60,11 +60,11 @@ let outlierTests =
                 TestExtensions.sequenceEqual Accuracy.high (zScoresOfSample ls) zLsSample "Z-Score of a sample was calculated incorrectly"
                 
             testCase "Population interval by Z-Score" <| fun()->
-                let populationInterval = Interval.CreateClosed (-0.3635434661,3.432572444)
+                let populationInterval = Interval.Closed (-0.3635434661,3.432572444)
                 compareIntervals (populationIntervalByZScore -0.3 0.5 ls) populationInterval "Z-Score interval in a population was calculated incorrectly"
 
             testCase "Sample interval by Z-Score" <| fun()->
-                let sampleInterval = Interval.CreateClosed (-0.4405465671,3.560910945)
+                let sampleInterval = Interval.Closed (-0.4405465671,3.560910945)
                 compareIntervals (sampleIntervalByZscore -0.3 0.5 ls) sampleInterval "Z-Score interval in a sample was calculated incorrectly"
         ]
 

--- a/tests/FSharp.Stats.Tests/TestExtensions.fs
+++ b/tests/FSharp.Stats.Tests/TestExtensions.fs
@@ -49,7 +49,9 @@
             s.Replace("\r\n","\n").Split("\n")
         |> Array.skip 1
         |> Array.map (fun x -> 
-            x.Split(", ") |> fun ([|a;b|]) -> a, float b
+            match x.Split(", ") with
+            | [|a;b|] -> a, float b
+            | _ -> failwith "invalid csv format"
          )
 
  


### PR DESCRIPTION
Fixes #321

- Fixes compiler warnings
- `Array.varOf` no longer constrained to float, test case added
- Hierarchical clustering no longer constrained to float with test added
- `Matrix.ofCols` and `Matrix.ofRows` remain float specific but warning fixed
-  `Quantile.normal` and `Quantile.normalInPlace`  also remail float specific


**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [x] Added unit tests regarding the added features
