### PR TITLE
Update shadowed operators

### DIFF
--- a/src/FSharp.Stats/Array.fs
+++ b/src/FSharp.Stats/Array.fs
@@ -40,7 +40,7 @@ module Array =
         let random = Random.rndgen
         let pivotIndex = left + random.NextInt() % (right - left + 1)
         let pivot = items.[pivotIndex]
-        if isNan pivot then
+        if Ops.isNan pivot then
             ~~~pivotIndex
         else
             swapInPlace pivotIndex right items // swap random pivot to right.
@@ -55,7 +55,7 @@ module Array =
             let rec loop i j =
                 if j <  right then 
                     let v = items.[j]
-                    if isNan v then   // true if nan
+                    if Ops.isNan v then   // true if nan
                         loop (~~~j) right // break beacause nan                    
                     else
                         if (v <= pivot) then

--- a/src/FSharp.Stats/DistanceMetrics.fs
+++ b/src/FSharp.Stats/DistanceMetrics.fs
@@ -116,7 +116,7 @@ module DistanceMetrics =
             let mutable dist = 0.
             for i in 0 .. (dim - 1) do
                 let x = v1.[i] - v2.[i]
-                if not (isNan x) then
+                if not (Ops.isNan x) then
                     dist <- dist + abs x
             dist
 
@@ -186,7 +186,7 @@ module DistanceMetrics =
                     let diff = abs (v1.[i] - v2.[i])
                     let d = diff ** p
                     
-                    if not (isNan d) then
+                    if not (Ops.isNan d) then
                         dist <- dist + d
 
                 if p >= 1.0 then
@@ -273,7 +273,7 @@ module DistanceMetrics =
             let mutable dist = 0.0
             for i in 0 .. (dim - 1) do
                 let x = a1.[i] - a2.[i]
-                if not (isNan x) then
+                if not (Ops.isNan x) then
                     dist <- dist + (x * x)
             float dist
 
@@ -311,7 +311,7 @@ module DistanceMetrics =
             let mutable dist = 0.0
             for i in 0 .. (dim - 1) do 
                 let x = a1.[i] - a2.[i]
-                if not (isNan x) then
+                if not (Ops.isNan x) then
                     dist <- dist + System.Math.Abs x
             dist
 
@@ -381,7 +381,7 @@ module DistanceMetrics =
                     let diff = abs (a1.[i] - a2.[i])
                     let d = diff ** p
                     
-                    if not (isNan d) then
+                    if not (Ops.isNan d) then
                         dist <- dist + d
 
                 if p >= 1.0 then

--- a/src/FSharp.Stats/Distributions/Bandwidth.fs
+++ b/src/FSharp.Stats/Distributions/Bandwidth.fs
@@ -43,7 +43,7 @@ module Bandwidth =
         /// </code>
         /// </example>
         let sturges ndataLength =
-            ceil (1. + log2 ndataLength)
+            ceil (1. + Ops.log2 ndataLength)
 
 
         /// <summary>The Rice Rule is presented as a simple alternative to Sturges's rule.</summary>
@@ -88,8 +88,8 @@ module Bandwidth =
     let forHistogram data =
         let data' =
             data
-            |> Seq.filter (fun v -> not (isNan v))
-            |> Seq.filter (fun v -> not (isInf v))
+            |> Seq.filter (fun v -> not (Ops.isNan v))
+            |> Seq.filter (fun v -> not (Ops.isInf v))
 
         let interval = Seq.range data' 
         let dmin,dmax = Interval.values interval

--- a/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
+++ b/src/FSharp.Stats/Distributions/Continuous/Gamma.fs
@@ -148,7 +148,7 @@ type Gamma =
         Gamma.CheckParam alpha beta
         match alpha,beta with
         | 0., 0. -> infNeg
-        | a , b when isPosInf(b) -> if a = x then infinity else 0. 
+        | a , b when Ops.isPosInf(b) -> if a = x then infinity else 0. 
         | 1., _ -> beta * exp(-beta*x)
         | _ -> Gamma.PDFLn alpha beta x |> exp
        
@@ -167,7 +167,7 @@ type Gamma =
         //shape rate
         match alpha,beta with
         | 0., 0. -> 0.
-        | a , b when isPosInf(b) -> if a = x then infinity else infNeg 
+        | a , b when Ops.isPosInf(b) -> if a = x then infinity else infNeg 
         | 1., _ -> log(beta) * (-beta*x)
         | _     -> (alpha - 1.) * log(x) - x / beta - (alpha * log(beta)
                     + SpecialFunctions.Gamma.gammaLn(alpha)) 

--- a/src/FSharp.Stats/Distributions/Discrete/Binomial.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Binomial.fs
@@ -21,7 +21,7 @@ type Binomial =
     
     // Binomial distribution helper functions.
     static member CheckParam p n = 
-        if n < 0 || p < 0. || p > 1. || isNan(p) then 
+        if n < 0 || p < 0. || p > 1. || Ops.isNan(p) then 
             failwith "Binomial distribution should be parametrized by n > 0.0 and 0 ≤ p ≤ 1."
 
     /// <summary>Computes the mode.</summary>

--- a/src/FSharp.Stats/Distributions/Discrete/Multinomial.fs
+++ b/src/FSharp.Stats/Distributions/Discrete/Multinomial.fs
@@ -16,7 +16,7 @@ type Multinomial =
         if n < 0 then
             failwith "Multinomial distribution should be parametrized by n >= 0."
         let checkBetween p =
-            p < 0. || p > 1. || isNan(p)
+            p < 0. || p > 1. || Ops.isNan(p)
         if (p |> Seq.map checkBetween |> Seq.exists id) then 
             failwith "Multinomial distribution should be parametrized by 0 ≤ p_i ≤ 1."
         

--- a/src/FSharp.Stats/Fitting/GoodnessOfFit.fs
+++ b/src/FSharp.Stats/Fitting/GoodnessOfFit.fs
@@ -424,14 +424,14 @@ module GoodnessOfFit =
                                 else 
                                     let rnd = rnd.Next(0,n)
                                     let tmp = zippedData.[rnd]
-                                    if not (isNan(fst tmp)) then
+                                    if not (Ops.isNan(fst tmp)) then
                                         zippedData.[rnd] <- (nan,nan)
                                         loop (i+1) (tmp::acc)
                                     else loop i acc
                             loop 0 []
                             )
                     //generate the kth subset out of the left over values in the original data set
-                    let rest = zippedData |> Array.filter (fun (a,b) -> not (isNan a))
+                    let rest = zippedData |> Array.filter (fun (a,b) -> not (Ops.isNan a))
                     //combine all the subsets
                     let subsequence = Array.append [|rest|] chunks 
                     

--- a/src/FSharp.Stats/Fitting/LinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/LinearRegression.fs
@@ -665,11 +665,11 @@ module LinearRegression =
                     let factor = 
                         //[for l = 0 to (level - 1) do yield i-l] 
                         List.init level (fun l -> i-l)
-                        |> List.filter (not << isNan)
+                        |> List.filter (not << Ops.isNan)
                         |> List.fold (fun acc c -> acc * (float c)) 1.
                     factor * coef.Coefficients.[i] * (pown x (i-level))
                     )
-                |> Array.filter (not << isNan)
+                |> Array.filter (not << Ops.isNan)
                 |> Array.sum
 
             /// <summary>

--- a/src/FSharp.Stats/Fitting/NonLinearRegression.fs
+++ b/src/FSharp.Stats/Fitting/NonLinearRegression.fs
@@ -236,7 +236,7 @@ module NonLinearRegression =
         ///
         let private validateBounds (lowerBound: vector) (upperBound: vector) (parameters: vector) =
             try
-                if Vector.map3 (fun l u x -> if l <= x && u >= x then x else nan) lowerBound upperBound parameters |> Vector.exists isNan then 
+                if Vector.map3 (fun l u x -> if l <= x && u >= x then x else nan) lowerBound upperBound parameters |> Vector.exists Ops.isNan then 
                     failwith "initial parameters are not within Bounds"
                 else 
                     ()

--- a/src/FSharp.Stats/Interpolation.fs
+++ b/src/FSharp.Stats/Interpolation.fs
@@ -2181,7 +2181,7 @@ module Interpolation =
             let xy = 
                 Seq.zip xData yData
                 // Remove nan
-                |> Seq.filter (fun (x,y) -> not (isNan x || isNan y || isInf x || isInf y))
+                |> Seq.filter (fun (x,y) -> not (Ops.isNan x || Ops.isNan y || Ops.isInf x || Ops.isInf y))
                 // sort by x
                 |> Seq.sortBy fst
                 |> Seq.groupBy fst

--- a/src/FSharp.Stats/Interval.fs
+++ b/src/FSharp.Stats/Interval.fs
@@ -205,7 +205,7 @@ type Interval<'a when 'a : comparison> =
                 | true  -> 
                     let current = projection e.Current
                     // fail if collection contains nan
-                    if isfloat && isNan current then 
+                    if isfloat && Ops.isNan current then 
                         //Interval.Empty 
                         invalidOp "Interval cannot be determined if collection contains nan"
                     else

--- a/src/FSharp.Stats/List.fs
+++ b/src/FSharp.Stats/List.fs
@@ -55,7 +55,7 @@ module List =
             | [] ->
                 // place pivot in equal pile
                 cont [] 0 [x] 1 [] 0
-            | y::ys when isNan y -> y
+            | y::ys when Ops.isNan y -> y
             | y::ys ->
                 if y < x then
                     // place item in less-than pile
@@ -84,7 +84,7 @@ module List =
         let rec loop before xs after =
             match xs with
             | [] -> failwith "Median of empty list"
-            | x::xs when isNan x -> x
+            | x::xs when Ops.isNan x -> x
             | x::xs ->
                 partition x xs (fun lts numlt eqs numeq gts numgt ->
                     if before + numlt > numeq + numgt + after then

--- a/src/FSharp.Stats/ML/Unsupervised/IterativeClustering.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/IterativeClustering.fs
@@ -121,7 +121,7 @@ module IterativeClustering =
     /// </code>
     /// </example>
     let private meanNaN (input: float []) = 
-        let isValid f = not (isNan f || isInf f)
+        let isValid f = not (Ops.isNan f || Ops.isInf f)
         let rec loop i sum count = 
             if i < input.Length then 
                 let current = input.[i]

--- a/src/FSharp.Stats/ML/Unsupervised/PrincipalComponentAnalysis.fs
+++ b/src/FSharp.Stats/ML/Unsupervised/PrincipalComponentAnalysis.fs
@@ -33,7 +33,7 @@ module PCA =
     /// </code>
     /// </example>
     let center m = 
-        if m |> Matrix.exists (fun x -> isNan x || isInf x) then 
+        if m |> Matrix.exists (fun x -> Ops.isNan x || Ops.isInf x) then 
             failwith "Computation not possible. Matrix contains invalid entries. Check for the existence of values equal to nan, infinity or -infinity."
         else
         let columnMeans =
@@ -68,7 +68,7 @@ module PCA =
     /// </code>
     /// </example>
     let compute m =  
-        if m |> Matrix.exists (fun x -> isNan x || isInf x) then 
+        if m |> Matrix.exists (fun x -> Ops.isNan x || Ops.isInf x) then 
             failwith "Computation not possible. Matrix contains invalid entries. Check for the existence of values equal to nan, infinity or -infinity."
         else
         let s,u,v = FSharp.Stats.Algebra.LinearAlgebra.SVD (m) 

--- a/src/FSharp.Stats/Ops.fs
+++ b/src/FSharp.Stats/Ops.fs
@@ -54,16 +54,6 @@ module Ops =
     /// </example>
     let log2 x = System.Math.Log(x, 2.0)
     
-    /// <summary>Returns the logarithm for x in base 10.</summary>
-    /// <remarks></remarks>
-    /// <param name="x"></param>
-    /// <returns></returns>
-    /// <example>
-    /// <code>
-    /// </code>
-    /// </example>
-    let log10 x = System.Math.Log10(x)    
-
     /// Returs true if x is nan (generics) equality
     //let inline isNan< ^T when ^T : equality > (num:^T) :  bool = num <> num
     let inline isNan num = num <> num

--- a/src/FSharp.Stats/Ops.fs
+++ b/src/FSharp.Stats/Ops.fs
@@ -3,8 +3,7 @@ namespace FSharp.Stats
 #nowarn "40"
 #nowarn "42"
 
-/// Operations module (automatically opened)
-[<AutoOpen>]
+/// Operations module
 module Ops =
     open System
     open System

--- a/src/FSharp.Stats/Ops.fs
+++ b/src/FSharp.Stats/Ops.fs
@@ -127,7 +127,7 @@ module Ops =
     /// <code>
     /// </code>
     /// </example>
-    let round (digits:int) (x:float) =
+    let roundTo (digits:int) (x:float) =
         System.Math.Round(x, digits)
     
     /// <summary>Signum function, assigns a positive sign to a with respect to the signing of b. </summary>

--- a/src/FSharp.Stats/Precision.fs
+++ b/src/FSharp.Stats/Precision.fs
@@ -15,9 +15,9 @@ module Precision =
     /// </code>
     /// </example>
     let almostEqualNormRelative maximumError a b  = 
-        if a |> isInf || b |> isInf then
+        if a |> Ops.isInf || b |> Ops.isInf then
             a = b 
-        elif a |> isNan || b |> isNan then
+        elif a |> Ops.isNan || b |> Ops.isNan then
             false 
         elif ((a - b) |> abs) < maximumError  then 
             true

--- a/src/FSharp.Stats/Quantile.fs
+++ b/src/FSharp.Stats/Quantile.fs
@@ -408,11 +408,11 @@ module Quantile =
         if (q < 0. || q > 1. || data.Length = 0) then
             nan
         elif (h' <= 0 || q = 0.) then
-            if Array.exists isNan data then 
+            if Array.exists Ops.isNan data then 
                 nan 
             else Array.min data
         elif (h' >= data.Length || q = 1.) then
-            if Array.exists isNan data then 
+            if Array.exists Ops.isNan data then 
                 nan 
             else Array.max data
         else

--- a/src/FSharp.Stats/Random.fs
+++ b/src/FSharp.Stats/Random.fs
@@ -72,7 +72,7 @@ module Random =
     /// </remarks>
     let boxMullerTransform() =
         let (u1,u2) = rndgen.NextFloat(),rndgen.NextFloat()
-        let z0 = sqrt(-2. * log u1) * cos (2. * pi * u2)
-        let z1 = sqrt(-2. * log u1) * sin (2. * pi * u2)
+        let z0 = sqrt(-2. * log u1) * cos (2. * Ops.pi * u2)
+        let z1 = sqrt(-2. * log u1) * sin (2. * Ops.pi * u2)
         z0,z1
         

--- a/src/FSharp.Stats/Seq.fs
+++ b/src/FSharp.Stats/Seq.fs
@@ -272,7 +272,7 @@ module Seq =
             let random = Random.rndgen
             let pivotIndex = left + random.NextInt() % (right - left + 1)
             let pivot = items.[pivotIndex]
-            if isNan pivot then
+            if Ops.isNan pivot then
                 ~~~pivotIndex
             else
                 swapInPlace pivotIndex right items // swap random pivot to right.
@@ -287,7 +287,7 @@ module Seq =
                 let rec loop i j =
                     if j <  right then 
                         let v = items.[j]
-                        if isNan v then   // true if nan
+                        if Ops.isNan v then   // true if nan
                             loop (~~~j) right // break beacause nan                    
                         else
                             if (v <= pivot) then        
@@ -1151,7 +1151,7 @@ module Seq =
         /// <returns>sum of squares</returns> 
         let sumOfSquares (xData:seq<float>) (exData:seq<float>) =
             let xX = Seq.zip xData exData 
-            Seq.fold (fun acc (x,ex) -> acc + square (x - ex)) 0. xX
+            Seq.fold (fun acc (x,ex) -> acc + Ops.square (x - ex)) 0. xX
 
 
         /// <summary>

--- a/src/FSharp.Stats/Signal/FFT.fs
+++ b/src/FSharp.Stats/Signal/FFT.fs
@@ -52,7 +52,7 @@ module FFT =
     // FFT Helper function
     let private fftAux (a : Complex array) n j sign m = 
         let w = 
-            let t = pi * float (sign * m) / float j 
+            let t = Ops.pi * float (sign * m) / float j 
             Complex(cos t, sin t)
         let mutable i = m 
         while i < n do 
@@ -90,7 +90,7 @@ module FFT =
     let private bluestein a = 
     
         let bluesteinSequence n = 
-            let s = pi / float n 
+            let s = Ops.pi / float n 
             Array.init n ( fun k -> 
                 let t = s * float(k * k) 
                 Complex (cos t, sin t)

--- a/src/FSharp.Stats/SpecialFunctions/Beta.fs
+++ b/src/FSharp.Stats/SpecialFunctions/Beta.fs
@@ -135,7 +135,7 @@ module Beta =
         let ai = 1.0 / a
         let ui = (1.0 - b) * x 
         let t1 = ui / (a + 1.0)
-        let z  = epsilon * ai
+        let z  = Ops.epsilon * ai
 
         let rec loop u t v s n =
             if (abs v > z) then 
@@ -149,12 +149,12 @@ module Beta =
         let s = loop ui ui t1 0. 2.  
         let u = a * log x
         
-        if ((a + b) < Gamma.maximum && abs u < logMax) then
+        if ((a + b) < Gamma.maximum && abs u < Ops.logMax) then
             let t = Gamma.gamma (a + b) / (Gamma.gamma a * Gamma.gamma b)
             s * t * System.Math.Pow(x, a)
         else
             let t = Gamma.gammaLn (a + b) - Gamma.gammaLn a - Gamma.gammaLn b + u + log s
-            if (t < logMin) then
+            if (t < Ops.logMin) then
                 0.0
             else
                 exp t

--- a/src/FSharp.Stats/SpecialFunctions/Gamma.fs
+++ b/src/FSharp.Stats/SpecialFunctions/Gamma.fs
@@ -186,7 +186,7 @@ module Gamma =
         match x with
         | x when x = 0. -> 0.
         | x when (x < 0.0 || a <= 0.0) -> nan
-        | x when (isPosInf x) -> 1.
+        | x when (Ops.isPosInf x) -> 1.
         | _ -> 
             if (x= 0.0) then 0.0
             elif (a >= ASWITCH) then
@@ -205,7 +205,7 @@ module Gamma =
         match x with
         | x when x = 0. -> 1.
         | x when (x < 0.0 || a <= 0.0) -> nan
-        | x when (isPosInf x) -> 0.
+        | x when (Ops.isPosInf x) -> 0.
         | _ -> 
             if (x= 0.0) then 1.0
             elif (a >= ASWITCH) then

--- a/src/FSharp.Stats/Testing/MultipleTesting.fs
+++ b/src/FSharp.Stats/Testing/MultipleTesting.fs
@@ -155,12 +155,12 @@ module MultipleTesting =
             let pvaluesExtValid =
                 pvaluesExt 
                 |> Array.indexed   
-                |> Array.filter (fun (i,p) -> not (isNan p))
+                |> Array.filter (fun (i,p) -> not (Ops.isNan p))
 
             let pvaluesExtInValid = 
                 pvaluesExt 
                 |> Array.indexed   
-                |> Array.filter (fun (i,p) -> (isNan p))
+                |> Array.filter (fun (i,p) -> (Ops.isNan p))
 
             // if all pvalues are none, just return the nans
             if pvaluesExtValid.Length = 0 then 
@@ -252,12 +252,12 @@ module MultipleTesting =
             let pvaluesExtValid =
                 pvaluesExt 
                 |> Array.indexed   
-                |> Array.filter (fun (i,p) -> not (isNan p))
+                |> Array.filter (fun (i,p) -> not (Ops.isNan p))
 
             let pvaluesExtInValid = 
                 pvaluesExt 
                 |> Array.indexed   
-                |> Array.filter (fun (i,p) -> (isNan p))
+                |> Array.filter (fun (i,p) -> (Ops.isNan p))
 
             // if all pvalues are none, just return the nans
             if pvaluesExtValid.Length = 0 then 

--- a/src/FSharp.Stats/Testing/PostHoc.fs
+++ b/src/FSharp.Stats/Testing/PostHoc.fs
@@ -50,7 +50,7 @@ module PostHoc =
         // Step 5. Calculate the F statistic per contrast
         Array.mapi2 (fun i sscV l' -> let fValue = sscV / MSw
                                       //printfn  "%f %b " fValue (nan.Equals(fValue))
-                                      if isNan fValue then
+                                      if Ops.isNan fValue then
                                         createContrast i l' Db MSw nan nan sscV 
                                       else
                                         let FTest = createFTest fValue 1. Dw                                         
@@ -98,7 +98,7 @@ module PostHoc =
     
         // Step 4. Calculate the q statistic per contrast
         Array.mapi  (fun i (qValue,l)  ->
-                            if isNan qValue then
+                            if Ops.isNan qValue then
                                 createContrast i l Dw MSw nan nan Sw  
                             else
                                 let significance = 
@@ -152,7 +152,7 @@ module PostHoc =
         // Step 4. Calculate the F statistic per contrast
         stats
         |> Array.mapi (fun i (tValue,meanDiff)  ->
-            if isNan tValue then
+            if Ops.isNan tValue then
                 createContrast i meanDiff db msw nan nan ssw  
             else
                 let tTest = createTTest tValue dw

--- a/src/FSharp.Stats/Testing/SAM.fs
+++ b/src/FSharp.Stats/Testing/SAM.fs
@@ -212,7 +212,7 @@ module SAM =
                             tnew
                             )
                     tt2
-                    |> Array.filter (fun t -> not (isNan t) && not (isInf t)) 
+                    |> Array.filter (fun t -> not (Ops.isNan t) && not (Ops.isInf t)) 
                     |> Seq.medianAbsoluteDev
                     )
                 |> fun x -> 

--- a/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
+++ b/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
@@ -420,10 +420,10 @@ let chiSquaredTests =
                 Expect.floatClose Accuracy.veryHigh testCase 0. "Should be equal"
             testCase "CDF.testCaseDof1X-infinity" <| fun () ->
                 let testCase = 1. - (Continuous.ChiSquared.CDF 1. -infinity)
-                Expect.isTrue (isNan testCase) "Should be NaN"
+                Expect.isTrue (Ops.isNan testCase) "Should be NaN"
             testCase "CDF.testCaseDof1XNan" <| fun () ->
                 let testCase = 1. - (Continuous.ChiSquared.CDF 1. nan)
-                Expect.isTrue (isNan testCase) "Should be NaN"
+                Expect.isTrue (Ops.isNan testCase) "Should be NaN"
             //TestCases from Williams RBG, Introduction to Statistics for Geographers and Earth Scientist, 1984, DOI 10.1007/978-1-349-06815-9 p 333
             testCase "CDF.testCase1" <| fun () ->
                 let testCase = 1. - (Continuous.ChiSquared.CDF 20. 12.443)
@@ -540,35 +540,35 @@ let chiSquaredTests =
                 Expect.floatClose Accuracy.medium (testCase.CDF 1.) 0.682689 "Should be equal"
                 Expect.floatClose Accuracy.low (testCase.CDF 10.) 0.998 "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.CDF infinity) 1. "Should be equal"
-                Expect.isTrue (testCase.CDF -1. |> isNan) "Should be equal"
-                Expect.isTrue (testCase.CDF -infinity |> isNan) "Should be equal"
-                Expect.isTrue (testCase.CDF nan |> isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF -1. |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF -infinity |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF nan |> Ops.isNan) "Should be equal"
                 Expect.isTrue (testCase.PDF 0. = infinity) "Should be equal"
                 Expect.floatClose Accuracy.medium (testCase.PDF 1.) 0.24197 "Should be equal"
                 Expect.floatClose Accuracy.low (testCase.PDF 10.) 0.00085 "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.PDF infinity) 0. "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.PDF -infinity) 0. "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.PDF -1.) 0. "Should be equal"
-                Expect.isTrue (isNan <| testCase.PDF nan) "Should be equal"
+                Expect.isTrue (Ops.isNan <| testCase.PDF nan) "Should be equal"
             testCase "chiSquaredInfinity" <| fun () ->
                 let testCase = Continuous.ChiSquared.Init infinity
                 Expect.isTrue (testCase.Mean = infinity) "Should be equal"
                 Expect.isTrue (testCase.Variance = infinity) "Should be equal"
                 Expect.isTrue (testCase.StandardDeviation = infinity) "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.CDF 0.) 0. "Should be equal"
-                Expect.isTrue (testCase.CDF 1. |> isNan) "Should be equal"
-                Expect.isTrue (testCase.CDF 10. |> isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF 1. |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF 10. |> Ops.isNan) "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.CDF infinity) 1. "Should be equal"
-                Expect.isTrue (testCase.CDF -1. |> isNan) "Should be equal"
-                Expect.isTrue (testCase.CDF -infinity |> isNan) "Should be equal"
-                Expect.isTrue (testCase.CDF nan |> isNan) "Should be equal"
-                Expect.isTrue (testCase.PDF 0. |> isNan) "Should be equal"
-                Expect.isTrue (testCase.PDF 1. |> isNan) "Should be equal"
-                Expect.isTrue (testCase.PDF 10. |> isNan) "Should be equal"
-                Expect.isTrue (testCase.PDF infinity |> isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF -1. |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF -infinity |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.CDF nan |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.PDF 0. |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.PDF 1. |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.PDF 10. |> Ops.isNan) "Should be equal"
+                Expect.isTrue (testCase.PDF infinity |> Ops.isNan) "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.PDF -infinity) 0. "Should be equal"
                 Expect.floatClose Accuracy.veryHigh (testCase.PDF -1.) 0. "Should be equal"
-                Expect.isTrue (isNan <| testCase.PDF nan) "Should be equal"
+                Expect.isTrue (Ops.isNan <| testCase.PDF nan) "Should be equal"
         ]
     ]
 
@@ -840,7 +840,7 @@ let FDistributionTests =
             let testcase3   = Continuous.F.Mean dof1 dof2_2
             let r_value     = nan
             Expect.isTrue
-                ((isNan testcase)&& isNan(r_value)&&isNan(testcase2)&&isNan(testcase3))
+                ((Ops.isNan testcase)&& Ops.isNan(r_value)&&Ops.isNan(testcase2)&&Ops.isNan(testcase3))
                 (sprintf "Continuous.F.Mean with dof<=2 does not return nan %A %A %A" testcase testcase2 testcase3 )
 
         testCase "Continuous.F.Mean_dof1=Infininty" <| fun () ->
@@ -860,7 +860,7 @@ let FDistributionTests =
             let testcase    = Continuous.F.Mean dof1 dof2
             let r_value     = nan
             Expect.isTrue
-                ((isNan testcase)&& isNan(r_value))
+                ((Ops.isNan testcase)&& Ops.isNan(r_value))
                 (sprintf "Continuous.F.Mean with dof<=2 does not return nan %A" testcase  )
         
         testCase "Continuous.F.Mean_dof1&2=Infininty" <| fun () ->
@@ -869,7 +869,7 @@ let FDistributionTests =
             let testcase    = Continuous.F.Mean dof1 dof2
             let r_value     = nan
             Expect.isTrue
-                ((isNan testcase)&& isNan(r_value))
+                ((Ops.isNan testcase)&& Ops.isNan(r_value))
                 (sprintf "Continuous.F.Mean with dof<=2 does not return nan %A" testcase  )
 
         testCase "Continuous.F.Variance" <| fun () ->
@@ -888,11 +888,11 @@ let FDistributionTests =
             let dof2s       = [4. .. 0.5 .. 0.]
             let testcase    = 
                 dof2s|>
-                List.map(fun dof2 -> Continuous.F.Variance dof1 dof2 |> isNan)
+                List.map(fun dof2 -> Continuous.F.Variance dof1 dof2 |> Ops.isNan)
             let r_value     = nan
 
             Expect.isTrue
-                (isNan(r_value)&& (List.contains false testcase|> not))
+                (Ops.isNan(r_value)&& (List.contains false testcase|> not))
                 (sprintf "Continuous.F.Variance with dof<=2 does not return nan")
         
         testCase "Continuous.F.StandardDeviation" <| fun () ->
@@ -911,11 +911,11 @@ let FDistributionTests =
             let dof2s       = [4. .. 0.5 .. 0.]
             let testcase    = 
                 dof2s|>
-                List.map(fun dof2 -> Continuous.F.StandardDeviation dof1 dof2 |> isNan)
+                List.map(fun dof2 -> Continuous.F.StandardDeviation dof1 dof2 |> Ops.isNan)
             let r_value     = nan
 
             Expect.isTrue
-                (isNan(r_value)&& (List.contains false testcase|> not))
+                (Ops.isNan(r_value)&& (List.contains false testcase|> not))
                 (sprintf "Continuous.F.Variance with dof<=2 does not return nan")
         
         testCase "Continuous.F.Sample" <| fun () ->
@@ -924,10 +924,10 @@ let FDistributionTests =
             let testcase    = 
                 [for i=0 to 10000 do Continuous.F.Sample dof1 dof2]
                 |> List.mean
-                |> roundTo 5
+                |> Ops.roundTo 5
                 
             let r_value     = 
-                roundTo 5 (1.000359)
+                Ops.roundTo 5 (1.000359)
 
             Expect.floatClose
                 Accuracy.low
@@ -1025,13 +1025,13 @@ let FDistributionTests =
             let r_value_3     = nan
 
             Expect.isTrue
-                (isNan(testcase_1)&&isNan(r_value_1))
+                (Ops.isNan(testcase_1)&&Ops.isNan(r_value_1))
                 "Continuous.F.CDF with dof2=infinity does not yield the expected value"
             Expect.isTrue
-                (isNan(testcase_2)&&isNan(r_value_2))
+                (Ops.isNan(testcase_2)&&Ops.isNan(r_value_2))
                 "Continuous.F.CDF with dof1=infinity does not yield the expected value"
             Expect.isTrue
-                (isNan(testcase_3)&&isNan(r_value_3))
+                (Ops.isNan(testcase_3)&&Ops.isNan(r_value_3))
                 "Continuous.F.CDF with dof1&dof2=infinity does not yield the expected value"
 
         testCase "Continuous.F.Support" <| fun () ->

--- a/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
+++ b/tests/FSharp.Stats.Tests/DistributionsContinuous.fs
@@ -924,10 +924,10 @@ let FDistributionTests =
             let testcase    = 
                 [for i=0 to 10000 do Continuous.F.Sample dof1 dof2]
                 |> List.mean
-                |> round 5
+                |> roundTo 5
                 
             let r_value     = 
-                round 5 (1.000359)
+                roundTo 5 (1.000359)
 
             Expect.floatClose
                 Accuracy.low

--- a/tests/FSharp.Stats.Tests/DistributionsDiscrete.fs
+++ b/tests/FSharp.Stats.Tests/DistributionsDiscrete.fs
@@ -127,7 +127,7 @@ let bernoulliTests =
             test_OneCDFCases bernoulliDistribution_one
             //
             Expect.floatClose Accuracy.high (bernoulliDistribution_basicCase.CDF 0.8) (1.0 - bernoulliDistribution_basicCase.Mean) ""
-            Expect.isTrue (isNan <| bernoulliDistribution_nan.CDF 0.8) ""
+            Expect.isTrue (Ops.isNan <| bernoulliDistribution_nan.CDF 0.8) ""
             Expect.floatClose Accuracy.high (bernoulliDistribution_zero.CDF 0.8) (1.0 - bernoulliDistribution_zero.Mean) ""
             Expect.floatClose Accuracy.high (bernoulliDistribution_one.CDF 0.8) (1.0 - bernoulliDistribution_one.Mean) ""
         //// Tbh. i have no idea what this is for

--- a/tests/FSharp.Stats.Tests/Integration.fs
+++ b/tests/FSharp.Stats.Tests/Integration.fs
@@ -186,32 +186,32 @@ let numericalIntegrationTests =
             testCase "LeftEndpoint 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(LeftEndpoint)
                 //exact result is 0.25
-                let expected = round 5 (log 100.)
-                Expect.floatClose Accuracy.low (round 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.low (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "RightEndpoint 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(RightEndpoint)
                 //exact result is 0.25
-                let expected = round 5 (log 100.)
-                Expect.floatClose Accuracy.low (round 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.low (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "Midpoint 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(Midpoint)
                 //exact result is 0.25
-                let expected = round 5 (log 100.)
-                Expect.floatClose Accuracy.high (round 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.high (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "Trapezoidal 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(Trapezoidal)
                 //exact result is 0.25
-                let expected = round 5 (log 100.)
-                Expect.floatClose Accuracy.high (round 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.high (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "Simpson 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(Simpson)
                 //exact result is 0.25
-                let expected = round 5 (log 100.)
-                Expect.floatClose Accuracy.high (round 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.high (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
         ]
         testList "integrating nan function returns nan" [

--- a/tests/FSharp.Stats.Tests/Integration.fs
+++ b/tests/FSharp.Stats.Tests/Integration.fs
@@ -186,32 +186,32 @@ let numericalIntegrationTests =
             testCase "LeftEndpoint 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(LeftEndpoint)
                 //exact result is 0.25
-                let expected = roundTo 5 (log 100.)
-                Expect.floatClose Accuracy.low (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = Ops.roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.low (Ops.roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "RightEndpoint 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(RightEndpoint)
                 //exact result is 0.25
-                let expected = roundTo 5 (log 100.)
-                Expect.floatClose Accuracy.low (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = Ops.roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.low (Ops.roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "Midpoint 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(Midpoint)
                 //exact result is 0.25
-                let expected = roundTo 5 (log 100.)
-                Expect.floatClose Accuracy.high (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = Ops.roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.high (Ops.roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "Trapezoidal 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(Trapezoidal)
                 //exact result is 0.25
-                let expected = roundTo 5 (log 100.)
-                Expect.floatClose Accuracy.high (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = Ops.roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.high (Ops.roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
             testCase "Simpson 1/x" (fun _ ->
                 let actual = observations2 |> NumericalIntegration.definiteIntegral(Simpson)
                 //exact result is 0.25
-                let expected = roundTo 5 (log 100.)
-                Expect.floatClose Accuracy.high (roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
+                let expected = Ops.roundTo 5 (log 100.)
+                Expect.floatClose Accuracy.high (Ops.roundTo 5 actual) expected "LeftEndpoint did not return the correct result"
             )
         ]
         testList "integrating nan function returns nan" [

--- a/tests/FSharp.Stats.Tests/Optimization.fs
+++ b/tests/FSharp.Stats.Tests/Optimization.fs
@@ -23,7 +23,7 @@ let NelderMeadTests =
 
         // Fletcher and Powell's helic valley
         let fphv (x : vector) =
-            100. * (x[2] - 10. * (atan2 x[1] x[0]) / (2. * pi))**2. + 
+            100. * (x[2] - 10. * (atan2 x[1] x[0]) / (2. * Ops.pi))**2. + 
                 (sqrt(x[0]**2. + x[1]**2.) - 1.)**2. + x[2]**2.
 
         // Powell's Singular Function (PSF)

--- a/tests/FSharp.Stats.Tests/Testing.fs
+++ b/tests/FSharp.Stats.Tests/Testing.fs
@@ -1080,9 +1080,9 @@ let comparisonMetricsTests =
 type MyId = MyId of string
 
 let inline isSameNumber a b =
-    if isNan a && isNan b then true
-    elif isNegInf a && isNegInf b then true
-    elif isPosInf a && isPosInf b then true
+    if Ops.isNan a && Ops.isNan b then true
+    elif Ops.isNegInf a && Ops.isNegInf b then true
+    elif Ops.isPosInf a && Ops.isPosInf b then true
     else a = b
     
 type SAM.SAM<'id> when 'id :> IComparable with


### PR DESCRIPTION
Closes #332

`round` and `log10` in `FSharp.Stats.Ops` (which is auto opened) shadows existing operators. `log10` is equivalent and unneeded. `round` has a different signature than the existing `round` function.

Changes:
- remove `log10` which is already available
- rename `round` to `roundTo`


**[Required]** please make sure you checked that
 - [x] The project builds without problems on your machine

**[Optional]**
 - [ ] Added unit tests regarding the added features
